### PR TITLE
Remove bare except clauses

### DIFF
--- a/proselint/score.py
+++ b/proselint/score.py
@@ -66,7 +66,7 @@ def score(check=None):
                         input_val = int(input_val)
                         fp += input_val
                         tp += (num_errors - input_val)
-                except:
+                except ValueError:
                     pass
 
             print("Currently {} hits and {} false alarms\n---".format(tp, fp))

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -26,7 +26,7 @@ def memoize(f):
 
     try:
         cache = shelve.open(cachepath, protocol=2)
-    except:
+    except Exception:
         print('Could not open cache file %s, maybe name collision' % cachepath)
         cache = None
 


### PR DESCRIPTION
It's not good to have bare except clauses because you can accidentally catch what you didn't intend, for example `KeyboardInterrupt`. This can also hide bugs.