### PR TITLE
Fix backwards reference

### DIFF
--- a/proselint/checks/garner/mondegreens.py
+++ b/proselint/checks/garner/mondegreens.py
@@ -29,7 +29,7 @@ def check(text):
         ["beck and call",                 ["beckon call"]],
         ["for all intents and purposes",  ["for all intensive purposes"]],
         ["laid him on the green",         ["Lady Mondegreen"]],
-        ["Olive, the other reindeer",     ["all of the other reindeer"]],
+        ["all of the other reindeer",     ["Olive, the other reindeer"]],
         ["to the manner born",            ["to the manor born"]],
     ]
 


### PR DESCRIPTION
This flips the source list and preferred usage for 'All of the other reindeer,' which appears to have been implemented backwards.