### PR TITLE
Fix the Vim plugin

### DIFF
--- a/plugins/vim/readme.md
+++ b/plugins/vim/readme.md
@@ -1,29 +1,41 @@
-# Proselint plug-in for Vim
+# Proselint plugin for Vim
 
-Proselint plug-in for Vim is meant to work with
-[Syntastic](http://vimawesome.com/plugin/syntastic), as well as `proselint`
-executable already installed and on `$PATH`. Syntastic is a generic file-linter
-framework which expose various configuration option, like on which kind of file
-to run which linter, as well as on which even (save, load, ...) process the
-current file. Refer to [Syntastic](http://vimawesome.com/plugin/syntastic) docs
-for help with this.  
+Proselint plugin for Vim is meant to work with [syntastic][syntastic], as well
+as the `proselint` executable already installed and in your `$PATH`. Syntastic
+is a generic file-linter framework which exposes various configuration
+options, such as on which kind of file to run which linter, as well as
+on which event (save, load, ...) to process the current file. Refer to
+syntastic's docs for help with this.
 
-If you are a Vim user that you likely have a preferred way of managing your
-plug-ins. Find the installation directory of **Syntastic** and copy/or link
-this file in its `syntax_checkers/text` folder. 
+If you are a Vim user then you likely have a preferred way of managing
+your plugins. Copy or link `syntastic_proselint` next to your other Vim
+plugins, and enable it in your plugin manager. This should add `proselint`
+as a syntastic checker for filetypes `asciidoc`, `docbk`, `help`, `html`,
+`markdown`, `nroff`, `pod`, `rst`, `tex`, `texinfo`, `text`, and `xhtml`. If
+you open a file of the relevant type and run `:SyntasticInfo`, you should see
+`proselint` listed among the available checkers.
 
-Typically on unix-like system this will be
-`~/.vim/bundle/syntastic/syntax_checkers/text/`. 
+Next, edit your `vimrc` and add `proselint` to
+`g:syntastic_<filetype>_checkers` for the filetypes you plan to use, and
+restart Vim. You should now be able to get Proselint hints about your text
+files.
 
-Restart your Vim session/reload your vim settings/plug-ins, and you should now
-get Proselint hints in your text files. 
+If you want syntastic to filter out the messages produced by
+certain Proselint rules, add the IDs of the relevant rules to
+`g:syntastic_text_proselint_quiet_messages` like this:
+```vim
+let g:syntastic_text_proselint_quiet_messages = {
+    \ 'regex': [
+    \   '\m^butterick\.',
+    \   '\m^twain\.damn\>',
+    \ ] }
+```
+See `:h 'syntastic_quiet_messages'` in Vim for more information. See also
+`:h pattern` if you need help with Vim's regular expressions.
 
-Feel free to submit enhancement to this plug-in. 
+By default `g:syntastic_text_proselint_quiet_messages` is used for all
+filetypes known to the `proselint` checker, not just `text`.
 
-# Caveats
+Feel free to submit enhancement to this plugin.
 
-Depending on the Plug-ins Manager you use with Vim, Copying/linking this file
-into the bundle directory might prevent the Syntactic plug-in to update. Most
-Package manager should show an error on update if this is the case. 
-
-Just remove the file, update and put it back in place if this ever happen. 
+[syntastic]: https://github.com/scrooloose/syntastic

--- a/plugins/vim/syntastic_proselint/plugin/syntastic_proselint.vim
+++ b/plugins/vim/syntastic_proselint/plugin/syntastic_proselint.vim
@@ -1,0 +1,19 @@
+"============================================================================
+"File:        syntastic_proselint.vim
+"Description: Syntax checking plugin for syntastic
+"Author:      The Proselint team
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_proselint_plugin') || &compatible
+    finish
+endif
+let g:loaded_syntastic_proselint_plugin = 1
+
+if exists('g:syntastic_extra_filetypes')
+    call add(g:syntastic_extra_filetypes, 'help')
+else
+    let g:syntastic_extra_filetypes = ['help']
+endif
+
+" vim: set sw=4 sts=4 et fdm=marker:

--- a/plugins/vim/syntastic_proselint/syntax_checkers/asciidoc/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/asciidoc/proselint.vim
@@ -1,0 +1,1 @@
+../markdown/proselint.vim

--- a/plugins/vim/syntastic_proselint/syntax_checkers/docbk/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/docbk/proselint.vim
@@ -1,0 +1,1 @@
+../markdown/proselint.vim

--- a/plugins/vim/syntastic_proselint/syntax_checkers/help/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/help/proselint.vim
@@ -1,0 +1,1 @@
+../markdown/proselint.vim

--- a/plugins/vim/syntastic_proselint/syntax_checkers/html/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/html/proselint.vim
@@ -1,0 +1,1 @@
+../markdown/proselint.vim

--- a/plugins/vim/syntastic_proselint/syntax_checkers/markdown/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/markdown/proselint.vim
@@ -1,0 +1,24 @@
+"============================================================================
+"File:        proselint.vim
+"Description: Syntax checking plugin for syntastic
+"Author:      The Proselint team
+"
+"============================================================================
+
+let s:ft = expand('<sfile>:p:h:t', 1)
+
+if exists('g:loaded_syntastic_' . s:ft . '_proselint_checker')
+    finish
+endif
+let g:loaded_syntastic_{s:ft}_proselint_checker = 1
+
+if !exists('g:syntastic_' . s:ft . '_proselint_quiet_messages') && exists('g:syntastic_text_proselint_quiet_messages')
+    let g:syntastic_{s:ft}_proselint_quiet_messages = deepcopy(g:syntastic_text_proselint_quiet_messages)
+endif
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': s:ft,
+    \ 'name': 'proselint',
+    \ 'redirect': 'text/proselint'})
+
+" vim: set sw=4 sts=4 et fdm=marker:

--- a/plugins/vim/syntastic_proselint/syntax_checkers/nroff/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/nroff/proselint.vim
@@ -1,0 +1,1 @@
+../markdown/proselint.vim

--- a/plugins/vim/syntastic_proselint/syntax_checkers/pod/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/pod/proselint.vim
@@ -1,0 +1,1 @@
+../markdown/proselint.vim

--- a/plugins/vim/syntastic_proselint/syntax_checkers/rst/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/rst/proselint.vim
@@ -1,0 +1,1 @@
+../markdown/proselint.vim

--- a/plugins/vim/syntastic_proselint/syntax_checkers/tex/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/tex/proselint.vim
@@ -1,0 +1,1 @@
+../markdown/proselint.vim

--- a/plugins/vim/syntastic_proselint/syntax_checkers/texinfo/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/texinfo/proselint.vim
@@ -1,0 +1,1 @@
+../markdown/proselint.vim

--- a/plugins/vim/syntastic_proselint/syntax_checkers/text/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/text/proselint.vim
@@ -1,6 +1,6 @@
 "============================================================================
 "File:        proselint.vim
-"Description: Syntax checking plugin for syntastic.vim
+"Description: Syntax checking plugin for syntastic
 "Author:      The Proselint team
 "
 "============================================================================
@@ -10,19 +10,24 @@ if exists('g:loaded_syntastic_text_proselint_checker')
 endif
 let g:loaded_syntastic_text_proselint_checker = 1
 
+if !exists('g:syntastic_text_proselint_sort')
+    let g:syntastic_text_proselint_sort = 1
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_text_proselint_GetLocList() dict
-    let makeprg = self.makeprgBuild({'exe': 'proselint'})
+    let makeprg = self.makeprgBuild({})
 
-    let errorformat = '%f:%l:%c:%m'
+    let errorformat = '%f:%l:%c: %m'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'defaults': { 'type': 'Style' },
-        \ 'returns': [0, 1]})
+        \ 'defaults': { 'type': 'W', 'subtype': 'Style' },
+        \ 'preprocess': 'iconv',
+        \ 'returns': [0, 1] })
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
@@ -31,3 +36,5 @@ call g:SyntasticRegistry.CreateAndRegisterChecker({
 
 let &cpo = s:save_cpo
 unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:

--- a/plugins/vim/syntastic_proselint/syntax_checkers/xhtml/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/xhtml/proselint.vim
@@ -1,0 +1,1 @@
+../markdown/proselint.vim


### PR DESCRIPTION
* Turn `proselint.vim` into an external checker for syntastic
* Add support for filetypes `asciidoc`, `docbk`, `help`, `html`, `markdown`, `nroff`, `pod`, `rst`, `tex`, `texinfo`, and `xhtml`.
* Fix message encoding, add loclist sorting, fix defaults.
* Update `readme`.

Closes #340.