### PR TITLE
Added a check for things like 'wax lyrically' vs 'wax lyrical' as in Fowlers.

### DIFF
--- a/proselint/checks/garner/not_guilty.py
+++ b/proselint/checks/garner/not_guilty.py
@@ -5,7 +5,7 @@ layout:     post
 source:     Garner's Modern American Usage
 source_url: http://bit.ly/1T4alrY
 title:      Not guilty beyond a reasonable doubt.
-date:       2016-03-08 20:27:56
+date:       2016-03-09 15:50:31
 categories: writing
 ---
 
@@ -29,6 +29,6 @@ def check(text):
     """Check the text."""
     err = "misc.not_guilty"
     msg = u"'not guilty beyond a reasonable doubt' is an ambiguous phrasing."
-    regex = "not guilty beyond a reasonable doubt"
+    regex = r"not guilty beyond (a |any )?reasonable doubt"
 
     return existence_check(text, [regex], err, msg)

--- a/proselint/checks/garner/not_guilty.py
+++ b/proselint/checks/garner/not_guilty.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Not guilty beyond a reasonable doubt
+---
+layout:     post
+source:     Garner's Modern American Usage
+source_url: http://bit.ly/1T4alrY
+title:      Not guilty beyond a reasonable doubt.
+date:       2016-03-08 20:27:56
+categories: writing
+---
+
+This phrasing is ambiguous. The standard by which a jury decides criminal
+charges is this: a defendant is guilty only if the evidence shows, beyond a
+reasonable doubt, that he or she committed the crime. Otherwise, the defendant
+is not guilty. Thus, we say that a defendant was not found "guilty beyond a
+reasonable doubt."
+
+If somebody is found not guilty, say "not guilty." Omit the standard
+("beyond a reasonable doubt") to prevent a miscue.
+
+Not guilty beyond a reasonable doubt
+
+"""
+from proselint.tools import existence_check, memoize
+
+
+@memoize
+def check(text):
+    """Check the text."""
+    err = "misc.not_guilty"
+    msg = u"'not guilty beyond a reasonable doubt' is an ambiguous phrasing."
+    regex = "not guilty beyond a reasonable doubt"
+
+    return existence_check(text, [regex], err, msg)

--- a/proselint/checks/garner/not_guilty.py
+++ b/proselint/checks/garner/not_guilty.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Not guilty beyond a reasonable doubt
+"""Not guilty beyond a reasonable doubt.
+
 ---
 layout:     post
 source:     Garner's Modern American Usage
@@ -19,8 +20,9 @@ If somebody is found not guilty, say "not guilty." Omit the standard
 ("beyond a reasonable doubt") to prevent a miscue.
 
 Not guilty beyond a reasonable doubt
-
 """
+
+
 from proselint.tools import existence_check, memoize
 
 


### PR DESCRIPTION
Checks like this would be neater to implement if there were a tool that takes a pair of lists of words that form bad combinations (in this case [wax, waxed,...] and [lyrically, poetically, .....]) and flags when it sees one followed by another. This tool would need to take into account issue #378.

