### PR TITLE
Fix the Vim plugin to work with older versions of syntastic

### DIFF
--- a/plugins/vim/readme.md
+++ b/plugins/vim/readme.md
@@ -10,10 +10,10 @@ syntastic's docs for help with this.
 If you are a Vim user then you likely have a preferred way of managing
 your plugins. Copy or link `syntastic_proselint` next to your other Vim
 plugins, and enable it in your plugin manager. This should add `proselint`
-as a syntastic checker for filetypes `asciidoc`, `docbk`, `help`, `html`,
-`markdown`, `nroff`, `pod`, `rst`, `tex`, `texinfo`, `text`, and `xhtml`. If
-you open a file of the relevant type and run `:SyntasticInfo`, you should see
-`proselint` listed among the available checkers.
+as a syntastic checker for filetypes `asciidoc`, `help`, `html`, `markdown`,
+`nroff`, `pod`, `rst`, `tex`, `texinfo`, `text`, and `xhtml`. If you open a
+file of the relevant type and run `:SyntasticInfo`, you should see `proselint`
+listed among the available checkers.
 
 Next, edit your `vimrc` and add `proselint` to
 `g:syntastic_<filetype>_checkers` for the filetypes you plan to use, and

--- a/plugins/vim/syntastic_proselint/syntax_checkers/docbk/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/docbk/proselint.vim
@@ -1,1 +1,0 @@
-../markdown/proselint.vim

--- a/plugins/vim/syntastic_proselint/syntax_checkers/markdown/proselint.vim
+++ b/plugins/vim/syntastic_proselint/syntax_checkers/markdown/proselint.vim
@@ -7,10 +7,15 @@
 
 let s:ft = expand('<sfile>:p:h:t', 1)
 
-if exists('g:loaded_syntastic_' . s:ft . '_proselint_checker')
+if exists('g:loaded_syntastic_' . s:ft . '_proselint_checker') || !exists('g:_SYNTASTIC_VERSION')
     finish
 endif
 let g:loaded_syntastic_{s:ft}_proselint_checker = 1
+
+if s:ft !=# 'text' && !syntastic#util#versionIsAtLeast(split(g:_SYNTASTIC_VERSION, '[.-]'), [3, 7, 0, 54])
+    execute 'runtime! syntax_checkers/text/*.vim'
+    execute 'runtime! syntax_checkers/' . s:ft . '/*.vim'
+endif
 
 if !exists('g:syntastic_' . s:ft . '_proselint_quiet_messages') && exists('g:syntastic_text_proselint_quiet_messages')
     let g:syntastic_{s:ft}_proselint_quiet_messages = deepcopy(g:syntastic_text_proselint_quiet_messages)


### PR DESCRIPTION
* Syntastic has changed since the last official release 3.7.0.  Make the plugin work with older versions.
* Drop support for filetype `docbk`.  Older versions of syntastic don't have the necessary infrastructure to support `docbk` as an external checker.