### PR TITLE
Fixed exception in the TypeError handler when cache sync fails

### DIFF
--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -55,8 +55,8 @@ def memoize(f):
             return value
         except TypeError:
             call_to = f.__module__ + '.' + f.__name__
-            print(['Warning: could not disk cache call to ',
-                   '%s; it probably has unhashable args'] % (call_to))
+            print('Warning: could not disk cache call to %s;'
+                  'it probably has unhashable args' % call_to)
             return f(*args, **kwargs)
 
     return wrapped


### PR DESCRIPTION
Fixed attempting to perform string interpolation on a list:
```
  File "/usr/local/lib/python3.5/site-packages/proselint/tools.py", line 59, in wrapped
    '%s; it probably has unhashable args'] % (call_to))
TypeError: unsupported operand type(s) for %: 'list' and 'str'
```