### PR TITLE
Attempt to fix cache-related bugs

### DIFF
--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -9,7 +9,12 @@ from builtins import str
 
 import click
 import os
-from .tools import line_and_column, is_quoted
+from .tools import (
+    line_and_column,
+    is_quoted,
+    close_cache_shelves_after,
+    close_cache_shelves
+)
 from . import checks as pl
 import pkgutil
 import subprocess
@@ -165,6 +170,7 @@ def show_errors(filename, errors, output_json=False, compact=False):
 @click.option('--demo', is_flag=True)
 @click.option('--compact', is_flag=True)
 @click.argument('paths', nargs=-1, type=click.Path())
+@close_cache_shelves_after
 def proselint(paths=None, version=None, initialize=None, clean=None,
               debug=None, score=None, output_json=None, time=None, demo=None,
               compact=None):
@@ -205,6 +211,7 @@ def proselint(paths=None, version=None, initialize=None, clean=None,
             pass
 
     # Return an exit code
+    close_cache_shelves()
     if num_errors > 0:
         sys.exit(1)
     else:

--- a/tests/check.py
+++ b/tests/check.py
@@ -17,7 +17,8 @@ class Check(TestCase):
 
     def tearDown(self):
         """Placeholder for teardown procedure."""
-        pass
+        from proselint.tools import close_cache_shelves
+        close_cache_shelves()
 
     @property
     def this_check(self):


### PR DESCRIPTION
This is an attempt to fix most (maybe even all?) of the bugs associated with cache files. Namely #238, #313, and #399. The features added are:

* A little extra error info in the print statements to help troubleshooting 
* For dbm errors on shelve.open calls, a retry is attempted by deleting the old file and re-opening (mainly fixes issues with mixing Python versions like in #313)
* Directly address #238 by tracking open cache files and closing them before process ends.