### PR TITLE
Handle missing dbm module on some python 2.7 systems

### DIFF
--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -8,11 +8,15 @@ import sys
 import traceback
 import os
 import shelve
-import dbm
 import inspect
 import functools
 import re
 import hashlib
+
+try:
+    import dbm
+except ImportError:
+    import anydbm as dbm
 
 _cache_shelves = dict()
 


### PR DESCRIPTION
I didn't realize it, but apparently some systems don't have the dbm module for Python 2.7. Added a fallback to anydbm, whose error tuple should still do what we want.