### PR TITLE
Allow proselintrc to be overridden by user

### DIFF
--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -44,6 +44,7 @@ def run_initialization():
         except Exception:
             pass
 
+
 def load_options():
     """Read various proselintrc files, allowing user overrides."""
     possible_defaults = (

--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -44,11 +44,45 @@ def run_initialization():
         except Exception:
             pass
 
+def load_options():
+    """Read various proselintrc files, allowing user overrides."""
+    possible_defaults = (
+        '/etc/proselintrc',
+        os.path.join(proselint_path, '.proselintrc'),
+    )
+    options = {}
+    has_overrides = False
+
+    for filename in possible_defaults:
+        try:
+            options = json.load(open(filename))
+            break
+        except IOError:
+            pass
+
+    try:
+        user_options = json.load(open(os.path.expanduser('~/.proselintrc')))
+        has_overrides = True
+    except IOError:
+        pass
+
+    if has_overrides:
+        if 'max_errors' in user_options:
+            options['max_errors'] = user_options['max_errors']
+        if 'checks' in user_options:
+            for (key, value) in user_options['checks'].items():
+                try:
+                    options['checks'][key] = value
+                except KeyError:
+                    pass
+
+    return options
+
 
 def lint(input_file, debug=False):
     """Run the linter on the input file."""
     # Load the options.
-    options = json.load(open(os.path.join(proselint_path, '.proselintrc')))
+    options = load_options()
 
     # Extract the checks.
     sys.path.append(proselint_path)


### PR DESCRIPTION
Check paths `/etc/proselintrc`, package copy of `.proselintrc`, and `~/.proselintrc` for check settings. The values in `~/.proselintrc`, if it exists, will take precedence over the defaults (merge over).

Also, I wanted to add a configuration option that defaults to `~/.proselintrc` but I was not sure of the best way to do that with the Click API.