### PR TITLE
Do not open file for reading and writing

### DIFF
--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -203,7 +203,7 @@ def proselint(paths=None, version=None, initialize=None, clean=None,
     num_errors = 0
     for fp in filepaths:
         try:
-            f = click.open_file(fp, 'r+', encoding="utf-8")
+            f = click.open_file(fp, 'r', encoding="utf-8")
             errors = lint(f, debug=debug)
             num_errors += len(errors)
             show_errors(fp, errors, output_json, compact=compact)


### PR DESCRIPTION
This makes files that are readable but not owned by the user able to be checked (mode `0o644`, etc).