### PR TITLE
Fixed spelling

### DIFF
--- a/proselint/checks/sexism/misc.py
+++ b/proselint/checks/sexism/misc.py
@@ -39,7 +39,7 @@ def check(text):
         ["lawyer",           ["lady lawyer"]],
         ["doctor",           ["woman doctor"]],
         ["bookseller",       ["female booksalesman"]],
-        ["air pilot",        ["femaile airman"]],
+        ["air pilot",        ["female airman"]],
         ["executor",         ["executrix"]],
         ["prosecutor",       ["prosecutrix"]],
         ["testator",         ["testatrix"]],


### PR DESCRIPTION
Believe "femaile airman" to be a spelling mistake, though I haven't read Garner's Modern American Usage or encountered either version before so can't be sure. 