### PR TITLE
Change file opening to replace characters on UTF-8 decode errors

### DIFF
--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -112,7 +112,7 @@ def proselint(paths=None, version=None, clean=None, debug=None,
     num_errors = 0
     for fp in filepaths:
         try:
-            f = click.open_file(fp, 'r', encoding="utf-8")
+            f = click.open_file(fp, 'r', encoding="utf-8", errors="replace")
             errors = lint(f, debug=debug)
             num_errors += len(errors)
             print_errors(fp, errors, output_json, compact=compact)


### PR DESCRIPTION
Fixes #504 

I'm not sure what project owners would prefer to do when reading a file with invalid UTF-8 sequences, but here's a compromise (replace invalid characters on error).

I verified that the file attached in the issue failed on my box under both Python 2 and 3, and that the fix works under both Python 2 and 3 on the new file.