### PR TITLE
Removing relative directory line on extract_files function in the command line interface

### DIFF
--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -112,7 +112,6 @@ def proselint(paths=None, version=None, clean=None, debug=None,
     num_errors = 0
     for fp in filepaths:
         try:
-
             f = click.open_file(fp, 'r', encoding="utf-8", errors="replace")
             errors = lint(f, debug=debug)
             num_errors += len(errors)
@@ -134,10 +133,9 @@ def extract_files(files):
     legal_extensions = [".md", ".txt", ".rtf", ".html", ".tex", ".markdown"]
 
     for f in files:
-
         # If it's a directory, recursively walk through it and find the files.
         if os.path.isdir(f):
-            for dir_, dirnames_, filenames in os.walk(f):
+            for dir_, _, filenames in os.walk(f):
                 for filename in filenames:
                     fn, file_extension = os.path.splitext(filename)
                     if file_extension in legal_extensions:

--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -112,6 +112,7 @@ def proselint(paths=None, version=None, clean=None, debug=None,
     num_errors = 0
     for fp in filepaths:
         try:
+
             f = click.open_file(fp, 'r', encoding="utf-8", errors="replace")
             errors = lint(f, debug=debug)
             num_errors += len(errors)
@@ -136,13 +137,12 @@ def extract_files(files):
 
         # If it's a directory, recursively walk through it and find the files.
         if os.path.isdir(f):
-            for dir_, _, filenames in os.walk(f):
+            for dir_, dirnames_, filenames in os.walk(f):
                 for filename in filenames:
                     fn, file_extension = os.path.splitext(filename)
                     if file_extension in legal_extensions:
-                        rel_dir = os.path.relpath(dir_, f)
-                        rel_file = os.path.join(rel_dir, filename)
-                        expanded_files.append(rel_file)
+                        joined_file = os.path.join(dir_, filename)
+                        expanded_files.append(joined_file)
 
         # Otherwise add the file directly.
         else:


### PR DESCRIPTION
This is an attempt to fix #539 . I'm not sure why the relative directory comparison was originally included, hopefully this doesn't break anything. I tested this on the following patterns:

```
proselint proselint
proselint /home/catherine/python_projects/proselint/proselint
proselint CONTRIBUTING.md
proselint ~/python_projects/proselint/proselint
proselint CONTRIBUTING.md proselint
```

Everything seemed to work... 