### PR TITLE
Add "color" to inconsistent spelling

### DIFF
--- a/proselint/checks/consistency/spelling.py
+++ b/proselint/checks/consistency/spelling.py
@@ -33,6 +33,7 @@ def check(text):
         ["advisor", "adviser"],
         # ["analyse", "analyze"],
         ["centre", "center"],
+        ["colour", "color"],
         ["emphasise", "emphasize"],
         ["finalise", "finalize"],
         ["focussed", "focused"],


### PR DESCRIPTION
The web version of proselint doesn't find the phrase "color on colour" invalid. This pull request may fix that.