### PR TITLE
Fix #540

### DIFF
--- a/proselint/checks/typography/exclamation.py
+++ b/proselint/checks/typography/exclamation.py
@@ -24,7 +24,7 @@ def check_repeated_exclamations(text):
     err = "leonard.exclamation.multiple"
     msg = u"Stop yelling. Keep your exclamation points under control."
 
-    regex = r"[^A-Z]\b((\s[A-Z]+){3,})"
+    regex = r"[\!]\s*?[\!]{1,}"
 
     return existence_check(
         text, [regex], err, msg, require_padding=False, ignore_case=False,

--- a/tests/test_leonard.py
+++ b/tests/test_leonard.py
@@ -1,0 +1,27 @@
+"""Test garner.dates."""
+from __future__ import absolute_import
+from __future__ import print_function
+
+from .check import Check
+from proselint.checks.typography import exclamation
+
+
+class TestCheck(Check):
+    """Test class for leonard.exclamation."""
+
+    __test__ = True
+
+    def test_capitalization_and_no_exclamation(self):
+        """Don't throw error when phrase has capitalization."""
+        text = """
+             The QUICK BROWN fox juMPED over the lazy cat.
+        """
+        errors = exclamation.check_repeated_exclamations(text)
+        assert len(errors) == 0
+
+    def test_exclamation(self):
+        """Test leonard.exclamation. with exclamation marks."""
+        text = """Sally sells seashells and they were too expensive!!!!"""
+        errors = exclamation.check_repeated_exclamations(text)
+        print(errors)
+        assert len(errors) == 1


### PR DESCRIPTION
This matches more than two exclamation marks, ignores capital letters, and some white space effectively fixing #540 .