### PR TITLE
Add "kind of" and "mildly" to uncomparables

### DIFF
--- a/proselint/checks/uncomparables/misc.py
+++ b/proselint/checks/uncomparables/misc.py
@@ -64,7 +64,9 @@ def check(text):
         "quite",
         "largely",
         "extremely",
-        "increasingly"
+        "increasingly",
+        "kind of",
+        "mildly"
     ]
 
     uncomparables = [


### PR DESCRIPTION
This commit is based from a user report:

> 'very unique' is caught, but not 'kind of unique' or 'mildly unique' or similar.