### PR TITLE
turn on the lgbtq checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ You can disable any of the checks by modifying `.proselintrc`.
 | `hedging.misc` | Not hedging |
 | `hyperbole.misc` | Not being hyperbolic |
 | `jargon.misc` | Avoiding miscellaneous jargon |
+| `lgbtq.offensive_terms` | Avoding offensive LGBTQ terms |
+| `lgbtq.terms` | Misused LGBTQ terms |
 | `lexical_illusions.misc` | Avoiding lexical illusions |
 | `links.broken` | Linking only to existing sites |
 | `malapropisms.misc` | Avoiding common malapropisms |

--- a/proselint/.proselintrc
+++ b/proselint/.proselintrc
@@ -18,6 +18,8 @@
         "hyperbole.misc"                : true,
         "jargon.misc"                   : true,
         "lexical_illusions.misc"        : true,
+        "lgbtq.offensive_terms"         : true, 
+        "lgbtq.terms"                   : true,
         "links.broken"                  : false,
         "malapropisms.misc"             : true,
         "misc.apologizing"              : true,

--- a/site/_posts/2014-06-10-checks.md
+++ b/site/_posts/2014-06-10-checks.md
@@ -25,6 +25,8 @@ Here is a list of what <tt>proselint</tt> checks.
 | `hedging.misc` | Not hedging |
 | `hyperbole.misc` | Not being hyperbolic |
 | `jargon.misc` | Avoiding miscellaneous jargon |
+| `lgbtq.offensive_terms` | Avoding offensive LGBTQ terms |
+| `lgbtq.terms` | Misused LGBTQ terms |
 | `lexical_illusions.misc` | Avoiding lexical illusions |
 | `links.broken` | Linking only to existing sites |
 | `malapropisms.misc` | Avoiding common malapropisms |


### PR DESCRIPTION
It appears the `lgbtq.offensive_terms` and `lgbtq.terms` modules are missing from the `.proselintrc` file. This adds them in and uses the checks from them by default.