### PR TITLE
Split gender bias error messages to allow for preferred forms

### DIFF
--- a/proselint/checks/sexism/misc.py
+++ b/proselint/checks/sexism/misc.py
@@ -52,11 +52,11 @@ def check(text):
         ["scientists",       ["women scientists"]]
         # ["hero",             ["heroine"]]
     ]
-    
+
     errors = preferred_forms_check(text, sexism, err, msg, ignore_case=False)
 
     msg = "Not a preferred form. Use '{}' instead of '{}'."
-    preferred_form = [
+    pref = [
             ["anchor",           ["anchorperson"]],
             ["chair",            ["chairperson"]],
             ["drafter",          ["draftperson"]],
@@ -66,7 +66,7 @@ def check(text):
             ["firefighter",      ["fireperson"]],
             ["mail carrier",     ["mailperson"]],
     ]
-    for x in preferred_forms_check(text, preferred_form, err, msg, ignore_case=False): 
-        errors.append(x) 
+    for x in preferred_forms_check(text, pref, err, msg, ignore_case=False):
+        errors.append(x)
 
     return errors

--- a/proselint/checks/sexism/misc.py
+++ b/proselint/checks/sexism/misc.py
@@ -16,21 +16,21 @@ Points out sexist language.
 from proselint.tools import memoize, preferred_forms_check
 
 
-@memoize
+#@memoize #TODO
 def check(text):
     """Suggest the preferred forms."""
     err = "sexism.misc"
     msg = "Gender bias. Use '{}' instead of '{}'."
 
     sexism = [
-        ["anchor",           ["anchorman", "anchorwoman", "anchorperson"]],
-        ["chair",            ["chairman", "chairwoman", "chairperson"]],
-        ["drafter",          ["draftman", "draftwoman", "draftperson"]],
-        ["ombuds",           ["ombudsman", "ombudswoman", "ombudsperson"]],
-        ["tribe member",     ["tribesman", "tribeswoman", "tribesperson"]],
-        ["police officer",   ["policeman", "policewoman", "policeperson"]],
-        ["firefighter",      ["fireman", "firewoman", "fireperson"]],
-        ["mail carrier",     ["mailman", "mailwoman", "mailperson"]],
+        ["anchor",           ["anchorman", "anchorwoman"]],
+        ["chair",            ["chairman", "chairwoman"]],
+        ["drafter",          ["draftman", "draftwoman"]],
+        ["ombuds",           ["ombudsman", "ombudswoman"]],
+        ["tribe member",     ["tribesman", "tribeswoman"]],
+        ["police officer",   ["policeman", "policewoman"]],
+        ["firefighter",      ["fireman", "firewoman"]],
+        ["mail carrier",     ["mailman", "mailwoman"]],
         ["history",          ["herstory"]],
         ["women",            ["womyn"]],
         ["poet",             ["poetess"]],
@@ -52,5 +52,21 @@ def check(text):
         ["scientists",       ["women scientists"]]
         # ["hero",             ["heroine"]]
     ]
+    
+    errors = preferred_forms_check(text, sexism, err, msg, ignore_case=False)
 
-    return preferred_forms_check(text, sexism, err, msg, ignore_case=False)
+    msg = "Not a preferred form. Use '{}' instead of '{}'."
+    preferred_form = [
+            ["anchor",           ["anchorperson"]],
+            ["chair",            ["chairperson"]],
+            ["drafter",          ["draftperson"]],
+            ["ombuds",           ["ombudsperson"]],
+            ["tribe member",     ["tribesperson"]],
+            ["police officer",   ["policeperson"]],
+            ["firefighter",      ["fireperson"]],
+            ["mail carrier",     ["mailperson"]],
+    ]
+    for x in preferred_forms_check(text, preferred_form, err, msg, ignore_case=False): 
+        errors.append(x) 
+
+    return errors

--- a/proselint/checks/sexism/misc.py
+++ b/proselint/checks/sexism/misc.py
@@ -16,7 +16,7 @@ Points out sexist language.
 from proselint.tools import memoize, preferred_forms_check
 
 
-#@memoize #TODO
+@memoize
 def check(text):
     """Suggest the preferred forms."""
     err = "sexism.misc"


### PR DESCRIPTION
As discussed in issue #564, split the gender bias misc into two parts: gendered language and preferred forms.