### PR TITLE
fix(checks): make am_pm check case sensitive

### DIFF
--- a/proselint/checks/dates_times/am_pm.py
+++ b/proselint/checks/dates_times/am_pm.py
@@ -19,7 +19,8 @@ def check_lowercase_periods(text):
     err = "dates_times.am_pm.lowercase_periods"
     msg = "With lowercase letters, the periods are standard."
 
-    return existence_check(text, [r"\d{1,2} ?[ap]m"], err, msg)
+    return existence_check(text, [r"\d{1,2} ?[ap]m"], err, msg,
+                           ignore_case=False)
 
 
 @memoize

--- a/tests/test_dates_times_am_pm.py
+++ b/tests/test_dates_times_am_pm.py
@@ -1,5 +1,4 @@
 """Tests for dates_times.am_pm check."""
-from __future__ import absolute_import
 
 from proselint.checks.dates_times import am_pm as chk
 
@@ -29,6 +28,8 @@ class TestCheck(Check):
             "It happened at 7 a.m.") == []
         assert chk.check_lowercase_periods(
             "It happened at 7 am.") != []
+        assert chk.check_lowercase_periods(
+            "On Wed, Sep 21, 2016 at 11:42 AM -0400, X wrote:") == []
 
     def test_smoke_check_spacing(self):
         """Basic smoke test.
@@ -65,9 +66,9 @@ class TestCheck(Check):
         dates_times.am_pm.check_redundancy.
 
         """
-        assert chk.check_redundancy(
-            "Basic smoke phrase without issues.") == []
-        assert chk.check_redundancy(
-            "It happened at 7 a.m.") == []
-        assert chk.check_redundancy(
-            "It happened at 7a.m. in the morning.") != []
+        assert len(chk.check_redundancy(
+            "Basic smoke phrase without issues.")) == 0
+        assert len(chk.check_redundancy(
+            "It happened at 7 a.m.")) == 0
+        assert len(chk.check_redundancy(
+            "It happened at 7a.m. in the morning.")) == 1

--- a/tests/test_existence_check.py
+++ b/tests/test_existence_check.py
@@ -41,6 +41,9 @@ class TestCheck(Check):
         assert len(
             chk("""ABC and abc are as easy as 123""",
                 self.L, self.err, self.msg, ignore_case=True)) == 2
+        assert len(
+            chk("""ABC and abc are as easy as 123""",
+                self.L, self.err, self.msg, ignore_case=False)) == 1
         assert chk(
             """abcabc are easy as 123""", self.L, self.err, self.msg) == []
 


### PR DESCRIPTION
Upon using proselint on an email, I immediately noticed that "lowercase am/pm" was not checking that am/pm was actually lower case.

I attempted to fix that here (and throw in some tests). But, I'm not a python hacker, and I have no idea what the usual workflows are for python projects. I did run `nosetests` within the tests directory, but my new test still fails. Is there some build step I'm missing? Or is my test broken?

P.S. It would be great if you could throw a few words into the contributing guide about how to approach the project as an absolute Python beginner. E.g. is `pip install --user --upgrade .` the right way to install a modified version? Or, how do I run it without even installing it locally? :)
