### PR TITLE
Remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install proselint
 - [x] [Sublime Text](https://github.com/amperser/proselint/tree/master/plugins/sublime/SublimeLinter-contrib-proselint)
 - [x] [Atom Editor](https://github.com/smockle/linter-proselint) (thanks to [Clay Miller](https://github.com/smockle)).
 - [x] [Emacs via Flycheck](https://github.com/amperser/proselint/tree/master/plugins/flycheck) (thanks to [Aaron Jacobs](https://github.com/atheriel))
-- [x] [Vim](https://github.com/amperser/proselint/tree/master/plugins/vim) (thanks to [Matthias Bussonnier](https://github.com/Carreau))
+- [x] [Vim](https://github.com/vim-syntastic/syntastic) (thanks to @lcd047 & @Carreau)
 - [x] [Phabricator's `arc` CLI](https://github.com/google/arc-proselint) (thanks to [Jeff Verkoeyen](https://github.com/jverkoey))
 - [x] [Danger](https://github.com/dbgrandi/danger-prose) (thanks to [David Grandinetti](https://github.com/dbgrandi) and [Orta Therox](https://github.com/orta)) 
 - [x] [Visual Studio Code](https://github.com/ppeszko/vscode-proselint) (thanks to [Patryk Peszko](https://github.com/ppeszko))


### PR DESCRIPTION
Thanks for making this, hoping to use it on a project soon!

This fixes a broken link to a Vim plugin. Browsing the Git history,
it looks like the plugin was extracted.

See 2a5cd46806f54ef12d1e5703da1a328fbe24b5aa for more details.
