### PR TITLE
"executive secretary" is not an oxymoron.

### DIFF
--- a/proselint/.proselintrc
+++ b/proselint/.proselintrc
@@ -35,6 +35,7 @@
         "misc.false_plurals"            : true,
         "misc.illogic"                  : true,
         "misc.inferior_superior"        : true,
+		"misc.institution_name"			: true,
         "misc.latin"                    : true,
         "misc.many_a"                   : true,
         "misc.metaconcepts"             : true,

--- a/proselint/checks/misc/institution_name.py
+++ b/proselint/checks/misc/institution_name.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+"""Common errors with institution names"""
+
+from proselint.tools import memoize, preferred_forms_check
+
+
+
+@memoize
+def check_vtech(text):
+    """Suggest the correct name.
+
+    source: Virginia Tech Division of Student Affairs
+    source_url: http://career.vt.edu/job-search/presenting_yourself/resumes/common-resume-mistakes.html
+    """
+    err = "institution.vtech"
+    msg = "Incorrect name. Use '{}' instead of '{}'."
+
+    institution = [
+        ["Virginia Polytechnic Institute and State University",          ["Virginia Polytechnic and State University"]],
+    ]
+    return preferred_forms_check(text, institution, err, msg)

--- a/proselint/checks/oxymorons/misc.py
+++ b/proselint/checks/oxymorons/misc.py
@@ -36,7 +36,6 @@ def check(text):
         "build down",
         "conspicuous absence",
         "exact estimate",
-        "executive secretary",
         "found missing",
         "intense apathy",
         "mandatory choice",


### PR DESCRIPTION
Executive secretaries work directly for and provide close administrative support to an executive.  http://learn.org/articles/What_Does_an_Executive_Secretary_Do.html

I noticed the false positive while reviewing this article: https://www.firstthings.com/article/2016/10/the-genius-of-winding-paths

> Shortly after the Civil War broke out, Olmsted relinquished his position as park superintendent to become executive secretary to the Sanitary Commission.

I can imagine secretaries finding this offensive, and I see no reason why it should belong.