### PR TITLE
Fix for #603

### DIFF
--- a/proselint/checks/misc/phrasal_adjectives.py
+++ b/proselint/checks/misc/phrasal_adjectives.py
@@ -21,11 +21,11 @@ def check_ly(text):
     """Check the text."""
     err = "garner.phrasal_adjectives.ly"
     msg = u"""No hyphen is necessary in phrasal adjectives with an adverb
-              ending in -ly, unless the -ly adverb is part of a longer 
+              ending in -ly, unless the -ly adverb is part of a longer
               phrase"""
-    
+
     regex = "\s[^\s-]+ly-"
-    
+
     return existence_check(text, [regex], err, msg,
                            require_padding=False, offset=-1)
 

--- a/proselint/checks/misc/phrasal_adjectives.py
+++ b/proselint/checks/misc/phrasal_adjectives.py
@@ -21,9 +21,12 @@ def check_ly(text):
     """Check the text."""
     err = "garner.phrasal_adjectives.ly"
     msg = u"""No hyphen is necessary in phrasal adjectives with an adverb
-              ending in -ly."""
-
-    return existence_check(text, ["ly-"], err, msg,
+              ending in -ly, unless the -ly adverb is part of a longer 
+              phrase"""
+    
+    regex = "\s[^\s-]+ly-"
+    
+    return existence_check(text, [regex], err, msg,
                            require_padding=False, offset=-1)
 
 


### PR DESCRIPTION
See http://regexr.com/3eljr for an example of this syntax.  

Rule from Garner: https://books.google.com/books?id=Sd3byNeBdR4C&lpg=PT2601&ots=lB4IMurLNj&dq=not-so-hotly-contested%20race%20garner&pg=PT2601#v=onepage&q=not-so-hotly-contested%20race%20garner&f=false

“When a phrasal adjective begins with an adverb ending in –ly, the convention is to drop the hyphen—e.g.: ‘With the hotly-contested [read hotly contested] Second Congressional District primary six days away, supporters of . . .’ But if the –ly adverb is part of a longer phrase, then the hyphen is mandatory (the not-so-hotly-contested race).”