### PR TITLE
executive secretary is not an oxymoron

### DIFF
--- a/proselint/checks/oxymorons/misc.py
+++ b/proselint/checks/oxymorons/misc.py
@@ -36,7 +36,6 @@ def check(text):
         "build down",
         "conspicuous absence",
         "exact estimate",
-        "executive secretary",
         "found missing",
         "intense apathy",
         "mandatory choice",
@@ -44,6 +43,7 @@ def check(text):
         "organized mess",
         # "pretty ugly",
         # "sure bet",
+        # "executive secretary",
     ]
 
     return existence_check(text, oxymorons, err, msg, offset=1, join=True)


### PR DESCRIPTION
Executive secretaries work directly for and provide close administrative support to an executive. http://learn.org/articles/What_Does_an_Executive_Secretary_Do.html

I noticed the false positive while reviewing this article: https://www.firstthings.com/article/2016/10/the-genius-of-winding-paths

> Shortly after the Civil War broke out, Olmsted relinquished his position as park superintendent to become executive secretary to the Sanitary Commission.

I can imagine secretaries finding this offensive, and I see no reason why it should belong.

(Note, I am resubmitting this pull request because I removed the branch that originally had it.  sorry for duplicate!)