### PR TITLE
fix_clear_cache_#624

### DIFF
--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -48,19 +48,32 @@ def clear_cache():
     click.echo("Deleting the cache...")
 
     # see issue #624
+    _delete_compiled_python_files()
+    _delete_cache()
+    _create_home_cache()
+
+
+def _delete_compiled_python_files():
+    """ Remove files with a 'pyc' extension """
     for path, _, files in os.walk(os.getcwd()):
-        for fname in [f for f in files if f.endswith(".pyc")]:
+        for fname in [f for f in files if os.path.splitext(f)[1] == ".pyc"]:
             try:
                 os.remove(os.path.join(path, fname))
             except OSError:
                 pass
 
+
+def _delete_cache():
+
+    proselint_cache = os.path.join("proselint", "cache")
     try:
-        proselint_cache = os.path.join("proselint", "cache")
         shutil.rmtree(proselint_cache)
     except OSError:
         pass
 
+
+def _create_home_cache():
+    """ create a cache in the users 'HOME' directory """
     try:
         os.makedirs(os.path.join(os.path.expanduser("~"), ".proselint"))
     except OSError:

--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -15,6 +15,7 @@ from .tools import (
     errors_to_json,
     lint,
 )
+import shutil
 import subprocess
 import sys
 from .version import __version__
@@ -45,16 +46,25 @@ def timing_test(corpus="0.1.0"):
 def clear_cache():
     """Delete the contents of the cache."""
     click.echo("Deleting the cache...")
-    subprocess.call(["find", ".", "-name", "'*.pyc'", "-delete"])
-    subprocess.call([
-        "rm",
-        "-rfv",
-        "proselint/cache",
-        "&&",
-        "mkdir",
-        "-p",
-        os.path.join(os.path.expanduser("~"), ".proselint"),
-    ])
+
+    # see issue #624
+    for path, _, files in os.walk(os.getcwd()):
+        for fname in [f for f in files if f.endswith(".pyc")]:
+            try:
+                os.remove(os.path.join(path, fname))
+            except OSError:
+                pass
+
+    try:
+        proselint_cache = os.path.join("proselint", "cache")
+        shutil.rmtree(proselint_cache)
+    except OSError:
+        pass
+
+    try:
+        os.makedirs(os.path.join(os.path.expanduser("~"), ".proselint"))
+    except OSError:
+        pass
 
 
 def print_errors(filename, errors, output_json=False, compact=False):

--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -54,7 +54,7 @@ def clear_cache():
 
 
 def _delete_compiled_python_files():
-    """ Remove files with a 'pyc' extension """
+    """Remove files with a 'pyc' extension."""
     for path, _, files in os.walk(os.getcwd()):
         for fname in [f for f in files if os.path.splitext(f)[1] == ".pyc"]:
             try:
@@ -64,7 +64,7 @@ def _delete_compiled_python_files():
 
 
 def _delete_cache():
-
+    """Remove the proselint cache."""
     proselint_cache = os.path.join("proselint", "cache")
     try:
         shutil.rmtree(proselint_cache)
@@ -73,7 +73,7 @@ def _delete_cache():
 
 
 def _create_home_cache():
-    """ create a cache in the users 'HOME' directory """
+    """Create a cache in the users 'HOME' directory."""
     try:
         os.makedirs(os.path.join(os.path.expanduser("~"), ".proselint"))
     except OSError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ gunicorn==19.4.5
 itsdangerous==0.24
 Jinja2==2.8.0
 MarkupSafe==0.23
+mock==2.0.0
 nose==1.3.7
 pep257==0.7.0
 pep8==1.7.0

--- a/tests/test_clear_cache.py
+++ b/tests/test_clear_cache.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Tests for the clear cache operation from proselint.command_line."""
 
 import os
 import unittest
@@ -17,7 +18,10 @@ try:
 except ImportError:
 
     class PermissionError(OSError):
+        """Introduced in Py3.3, emulate for earlier versions."""
+
         def __init__(self, *args, **kwargs):
+            """Constructor."""
             OSError.__init__(self, *args, **kwargs)
 
 try:
@@ -25,7 +29,10 @@ try:
 except ImportError:
 
     class FileNotFoundError(OSError):
+        """Introduced in Py3.3, emulate for earlier versions."""
+
         def __init__(self, *args, **kwargs):
+            """Constructor."""
             OSError.__init__(self, *args, **kwargs)
 
 try:
@@ -33,14 +40,18 @@ try:
 except ImportError:
 
     class IsADirectoryError(OSError):
+        """Introduced in Py3.3, emulate for earlier versions."""
+
         def __init__(self, *args, **kwargs):
+            """Constructor."""
             OSError.__init__(self, *args, **kwargs)
 
 
 class Test__delete_compiled_python_files(unittest.TestCase):
-    """ proselint.command_line._delete_compiled_python_files() """
+    """proselint.command_line._delete_compiled_python_files()."""
 
     def setUp(self):
+        """init common data."""
         self.base_dir = '.'
         self.python_file = 'a.py'
         self.pyc_file = 'a.pyc'
@@ -59,7 +70,7 @@ class Test__delete_compiled_python_files(unittest.TestCase):
     @mock.patch('os.walk')
     @mock.patch('os.remove')
     def test_delete_pyc_file(self, mock_remove, mock_walk):
-        """ Ensure 'pyc' files are removed """
+        """Ensure 'pyc' files are removed."""
         mock_walk.return_value = self.files
 
         cl._delete_compiled_python_files()
@@ -68,7 +79,7 @@ class Test__delete_compiled_python_files(unittest.TestCase):
     @mock.patch('os.walk')
     @mock.patch('os.remove')
     def test_files_not_deleted(self, mock_remove, mock_walk):
-        """ Ensure non 'pyc' files are not removed """
+        """Ensure non 'pyc' files are not removed."""
         mock_walk.return_value = self.files
         cl._delete_compiled_python_files()
 
@@ -81,73 +92,75 @@ class Test__delete_compiled_python_files(unittest.TestCase):
     @mock.patch('os.walk')
     @mock.patch('os.remove', side_effect=PermissionError)
     def test_no_permission(self, mock_remove, mock_walk):
-        """ Ignore if unable to delete files """
+        """Ignore if unable to delete files."""
         mock_walk.return_value = self.files
         cl._delete_compiled_python_files()
 
     @mock.patch('os.walk')
     @mock.patch('os.remove', side_effect=OSError)
     def test_on_oserror(self, mock_remove, mock_walk):
-        """ Ignore if OSError """
+        """Ignore if OSError."""
         mock_walk.return_value = self.files
         cl._delete_compiled_python_files()
 
     @mock.patch('os.walk')
     @mock.patch('os.remove', side_effect=FileNotFoundError)
     def test_files_not_found(self, mock_remove, mock_walk):
-        """ Ignore if file not found """
+        """Ignore if file not found."""
         mock_walk.return_value = self.files
         cl._delete_compiled_python_files()
 
     @mock.patch('os.walk')
     @mock.patch('os.remove', side_effect=IsADirectoryError)
     def test__remove_dir(self, mock_remove, mock_walk):
-        """ Ignore if attempt to delete a directory """
+        """Ignore if attempt to delete a directory."""
         mock_walk.return_value = self.files
         cl._delete_compiled_python_files()
 
 
 class Test__delete_cache(unittest.TestCase):
-    """ proselint.command_line.__delete_cache() """
+    """proselint.command_line.__delete_cache()."""
 
     def setUp(self):
+        """Init common data."""
         self.cache_path = os.path.join("proselint", "cache")
 
     @mock.patch('shutil.rmtree')
     def test_rm_cache(self, mock_rmtree):
-        """ Correct directory is removed """
+        """Correct directory is removed."""
         cl._delete_cache()
         mock_rmtree.assert_called_with(self.cache_path)
 
     @mock.patch('shutil.rmtree', side_effect=PermissionError)
     def test_no_permission(self, mock_rmtree):
-        """ Ignore if unable to delete """
+        """Ignore if unable to delete."""
         cl._delete_cache()
 
     @mock.patch('shutil.rmtree', side_effect=OSError)
     def test_on_oserror(self, mock_rmtree):
-        """ Ignore if general OSError """
+        """Ignore if general OSError."""
         cl._delete_cache()
 
 
 class Test_create_home_cache(unittest.TestCase):
-    """ proselint.command_line._create_home_cache() """
+    """proselint.command_line._create_home_cache()."""
 
     def setUp(self):
+        """Init common data."""
         self.cache_path = os.path.join(os.path.expanduser("~"), ".proselint")
 
     @mock.patch('os.makedirs')
     def test_makedir(self, mock_makedir):
-        """ correct directory is used """
+        """correct directory is used."""
         cl._create_home_cache()
         mock_makedir.assert_called_with(self.cache_path)
 
     @mock.patch('os.makedirs', side_effect=OSError)
     def test_on_oserror(self, mock_rmtree):
-        """ Ignore if general OSError """
+        """Ignore if general OSError."""
         cl._create_home_cache()
 
     @mock.patch('os.makedirs', side_effect=PermissionError)
     def test__no_permission(self, mock_rmtree):
-        """ Ignore if unable to delete """
+        """Ignore if unable to delete."""
         cl._create_home_cache()

--- a/tests/test_clear_cache.py
+++ b/tests/test_clear_cache.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from proselint import command_line as cl
+
+
+try:
+    from unittest import mock
+except ImportError:
+    # Py2.x
+    import mock
+
+try:
+    from builtins import PermissionError
+except ImportError:
+
+    class PermissionError(OSError):
+        def __init__(self, *args, **kwargs):
+            OSError.__init__(self, *args, **kwargs)
+
+try:
+    from builtins import FileNotFoundError
+except ImportError:
+
+    class FileNotFoundError(OSError):
+        def __init__(self, *args, **kwargs):
+            OSError.__init__(self, *args, **kwargs)
+
+try:
+    from builtins import IsADirectoryError
+except ImportError:
+
+    class IsADirectoryError(OSError):
+        def __init__(self, *args, **kwargs):
+            OSError.__init__(self, *args, **kwargs)
+
+
+class Test__delete_compiled_python_files(unittest.TestCase):
+    """ proselint.command_line._delete_compiled_python_files() """
+
+    def setUp(self):
+        self.base_dir = '.'
+        self.python_file = 'a.py'
+        self.pyc_file = 'a.pyc'
+        self.dot_pyc = '.pyc'
+
+        self.files = [
+            (self.base_dir, ('dummy',), (self.pyc_file,
+                                         self.python_file,
+                                         self.dot_pyc))
+        ]
+
+        self.pyc_file_path = os.path.join(self.base_dir, self.pyc_file)
+        self.python_file_path = os.path.join(self.base_dir, self.python_file)
+        self.dot_pyc_path = os.path.join(self.base_dir, self.python_file)
+
+    @mock.patch('os.walk')
+    @mock.patch('os.remove')
+    def test_delete_pyc_file(self, mock_remove, mock_walk):
+        """ Ensure 'pyc' files are removed """
+        mock_walk.return_value = self.files
+
+        cl._delete_compiled_python_files()
+        mock_remove.assert_called_with(self.pyc_file_path)
+
+    @mock.patch('os.walk')
+    @mock.patch('os.remove')
+    def test_files_not_deleted(self, mock_remove, mock_walk):
+        """ Ensure non 'pyc' files are not removed """
+        mock_walk.return_value = self.files
+        cl._delete_compiled_python_files()
+
+        with self.assertRaises(AssertionError):
+            mock_remove.assert_called_with(self.python_file_path)
+
+        with self.assertRaises(AssertionError):
+            mock_remove.assert_called_with(self.dot_pyc_path)
+
+    @mock.patch('os.walk')
+    @mock.patch('os.remove', side_effect=PermissionError)
+    def test_no_permission(self, mock_remove, mock_walk):
+        """ Ignore if unable to delete files """
+        mock_walk.return_value = self.files
+        cl._delete_compiled_python_files()
+
+    @mock.patch('os.walk')
+    @mock.patch('os.remove', side_effect=OSError)
+    def test_on_oserror(self, mock_remove, mock_walk):
+        """ Ignore if OSError """
+        mock_walk.return_value = self.files
+        cl._delete_compiled_python_files()
+
+    @mock.patch('os.walk')
+    @mock.patch('os.remove', side_effect=FileNotFoundError)
+    def test_files_not_found(self, mock_remove, mock_walk):
+        """ Ignore if file not found """
+        mock_walk.return_value = self.files
+        cl._delete_compiled_python_files()
+
+    @mock.patch('os.walk')
+    @mock.patch('os.remove', side_effect=IsADirectoryError)
+    def test__remove_dir(self, mock_remove, mock_walk):
+        """ Ignore if attempt to delete a directory """
+        mock_walk.return_value = self.files
+        cl._delete_compiled_python_files()
+
+
+class Test__delete_cache(unittest.TestCase):
+    """ proselint.command_line.__delete_cache() """
+
+    def setUp(self):
+        self.cache_path = os.path.join("proselint", "cache")
+
+    @mock.patch('shutil.rmtree')
+    def test_rm_cache(self, mock_rmtree):
+        """ Correct directory is removed """
+        cl._delete_cache()
+        mock_rmtree.assert_called_with(self.cache_path)
+
+    @mock.patch('shutil.rmtree', side_effect=PermissionError)
+    def test_no_permission(self, mock_rmtree):
+        """ Ignore if unable to delete """
+        cl._delete_cache()
+
+    @mock.patch('shutil.rmtree', side_effect=OSError)
+    def test_on_oserror(self, mock_rmtree):
+        """ Ignore if general OSError """
+        cl._delete_cache()
+
+
+class Test_create_home_cache(unittest.TestCase):
+    """ proselint.command_line._create_home_cache() """
+
+    def setUp(self):
+        self.cache_path = os.path.join(os.path.expanduser("~"), ".proselint")
+
+    @mock.patch('os.makedirs')
+    def test_makedir(self, mock_makedir):
+        """ correct directory is used """
+        cl._create_home_cache()
+        mock_makedir.assert_called_with(self.cache_path)
+
+    @mock.patch('os.makedirs', side_effect=OSError)
+    def test_on_oserror(self, mock_rmtree):
+        """ Ignore if general OSError """
+        cl._create_home_cache()
+
+    @mock.patch('os.makedirs', side_effect=PermissionError)
+    def test__no_permission(self, mock_rmtree):
+        """ Ignore if unable to delete """
+        cl._create_home_cache()


### PR DESCRIPTION
Replaces call outs to OS commands using os agnostic equivalents in the std lib.
Previously the OS callouts were being incorrectly evaluated and causing the
removal of the old cache to fail.