### PR TITLE
Emacs Flycheck plugin packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
+before_install:
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > emacs-version-manager-travis.sh && source ./emacs-version-manager-travis.sh
+  - evm install $EVM_EMACS --use --skip
+  - ( cd plugins/flycheck && cask )
 install:
 - pip install -r requirements.txt
 - gem install travis
@@ -17,6 +21,7 @@ install:
 - gem install kramdown
 - gem install danger
 - gem install danger-prose
+- ( cd plugins/flycheck && cask install )
 before_script:
 - travis lint -x --skip-completion-check
 script:
@@ -32,6 +37,8 @@ script:
     cd ..;
     wget --spider -e robots=off -w 1 -r -p http://www.proselint.com;
   fi
+- emacs --version
+- ( cd plugins/flycheck && cask exec buttercup -L . )
 after_success:
 - coveralls
 env:
@@ -41,6 +48,8 @@ env:
   - secure: EdCRjICaZwf3NOKPulTMZmWzx1d0yjbrOOv4YwcaDRpaTwhgzm/BIqi8UCWMY1zOk39+dZj+2Tn8pGOaDhiLbJimyEk8+xOiMmBXc2RBlKmsfktM+I+hZmVFDEOMVxI1VefV97Xhd8+hsojyDcgQ1vRPuv9tSrCvS/yY0eM0nHg=
   - secure: wvSA6fpl4oEsQHhp99csnyt2aXaGcFx6tsvhVteielmV7cLSblCK3Ne8wkzeGY0E8XXdu3P2sFbwRYiA26tOI87VaNRRutb4VptarSglB1w6UvLK11cepEfk89LIeFvLSC5aEdGeFhcp+gUCn3ZjicRSuMsEQgD2ifEOSzWc7FXbR3I5f3m58Xlw70y90Beoa3UginKZrB9cskUA60LgZDwwrTjvM4GzHpP3gSbL3+2dUaVxJBsiZFmGk9D2pfRc449oz5f9FxK0fgY2x0lDnxN9tQ0X7tF4icl/bzzIjkoSXrYCTtSdLFsG4P0Q7baN2jB3D81iCaqqoqyW0lspAAbQCLXcC9Qqjtlz+tZI6PARtbLn7O4P1IHyjMY6i1orX3OfYgP+51OyS8QTHabXVuluYspA2yrw7+UcNPuv3KUt8M4hFNEEYpAl3g8Ti17U48GZiLzpZyoYyqalE4psb4CfZH9GmEr5IQT9uMKcq+NHgOS01kwDT1ry3TuM0ttNgGy9jCtm5hWs9DQZwVLWXO/ao+w+6rf8kTBdfpzb4/JhH3Nsgfj7gwQlnGZZpE6RfEx3mZGRNFpbalSCnlTgBn7uKilcPOQPpCgU0zLkH3aidAruG6s+5dW+Q9WJfuZZiUhmcr1JYEIR+e9KkjJF6DDuqM+TZiwKTsbZntu29ao=
   - secure: DKS6Z+Jp7Mkgc/YKfXkUc1adkgoVt1LvvfMrXB241aw0G4d9sICLQDXBQgp79+ONpUKaeuoNkZt8K+0uMKpXkHixJB1zMBLRb3W+FXoaavHrtgamjEs4JA2UuHBKQ/5G+iMgmQqy1vSzYNLQT/QTOhl1y0Zg4x22wFFaNXSXqxKvcX+YzzwWddwAyirSX8spfeWQ9rG0hRuWJhhcO/nVL8lCf97aLgXCrPE8vy6JuGsRM1ZAZ/4yYEar3EXPWCtuRnuGeUX8GS+R2am0H9dTts+ERUIzwcyZbCdYSH6TjNpv24MWX0XD0VfhtQBkw9QmTGZ8wCypKTZ+w2HqPL9XEYOh70yEmr2I8gEgbXoOqa8I+WvrdYdKwl+iGPXDQLh60f5IZvWpWQAPOzDbeeAGFBx7rzxnuFem52fyzytp4lEYfuE11spOAk96fQJTPpVKDCS2tLvtMOAN/bIDghd+oriK4o1Qy5o3oZA0uResztAJTgm2Qx2NuqtFPr+Zv/NvPq6gSTlsLUkh1TVEolBB5SbDIzg8PEU7Ml6mdmGSWlYpzug2L01ly1GvJSnx0ObivSwQJibti8jAFiyD6DMBnlwrYmv8CXfc+NROZy35NADUE9VRaQRvObQJZfWFVvVCCmhqUNCYAceZ88Y2lgKMtL3t74rUAcWgbhrDYWZHo98=
+  matrix:
+    - EVM_EMACS=emacs-25.1-travis
 notifications:
   email:
     recipients:

--- a/plugins/flycheck/Cask
+++ b/plugins/flycheck/Cask
@@ -1,0 +1,10 @@
+;; -*- emacs-lisp -*-
+
+(source gnu)
+(source melpa)  ;; FIXME: use melpa-stable when it's back up
+
+(development
+ (depends-on "buttercup")
+
+ (depends-on "flycheck")
+ (depends-on "markdown-mode"))

--- a/plugins/flycheck/flycheck-proselint.el
+++ b/plugins/flycheck/flycheck-proselint.el
@@ -19,6 +19,7 @@
 ;;   '(add-hook 'flycheck-mode-hook #'flycheck-proselint-setup))
 ;; (add-hook 'text-mode-hook #'flycheck-mode)
 ;; (add-hook 'markdown-mode-hook #'flycheck-mode)
+;; (add-hook 'message-mode-hook #'flycheck-mode)
 ;; ...
 
 ;;; Code:
@@ -34,7 +35,7 @@
             (message (one-or-more not-newline)
                      (zero-or-more "\n" (any " ") (one-or-more not-newline)))
             line-end))
-  :modes (text-mode markdown-mode gfm-mode))
+  :modes (text-mode markdown-mode gfm-mode message-mode))
 
 ;;###autoload
 (defun flycheck-proselint-setup ()

--- a/plugins/flycheck/flycheck-proselint.el
+++ b/plugins/flycheck/flycheck-proselint.el
@@ -19,6 +19,8 @@
 
 ;;; Code:
 
+(require 'flycheck)
+
 (flycheck-define-checker proselint
   "A linter for prose."
   :command ("proselint" source-inplace)

--- a/plugins/flycheck/flycheck-proselint.el
+++ b/plugins/flycheck/flycheck-proselint.el
@@ -37,7 +37,7 @@
             line-end))
   :modes (text-mode markdown-mode gfm-mode message-mode))
 
-;;###autoload
+;;;###autoload
 (defun flycheck-proselint-setup ()
   "Add proselist to list of flycheck checkers."
   (add-to-list 'flycheck-checkers 'proselint))

--- a/plugins/flycheck/flycheck-proselint.el
+++ b/plugins/flycheck/flycheck-proselint.el
@@ -1,7 +1,23 @@
-; To install flycheck from MELPA, evaluate:
-;
-; (add-hook 'markdown-mode-hook #'flycheck-mode)
-; (add-hook 'text-mode-hook #'flycheck-mode)
+;;; flycheck-proselint.el --- a flycheck linter for prose
+
+;; Version: 0.8.0
+;; Package-Requires: ((flycheck "1"))
+;; Keywords: languages, convenience
+;; URL: http://proselint.com/
+
+;;; Commentary:
+
+;; proselint's goal is to aggregate knowledge about best practices in
+;; writing and to make that knowledge immediately accessible to all
+;; authors in the form of a linter for prose.
+;;
+;; This package provides a proselint checker for flycheck.
+;;
+;; To activate automatically, add to your .emacs, e.g.:
+;;   (add-hook 'markdown-mode-hook #'flycheck-mode)
+;;   (add-hook 'text-mode-hook #'flycheck-mode)
+
+;;; Code:
 
 (flycheck-define-checker proselint
   "A linter for prose."
@@ -13,4 +29,9 @@
                      (zero-or-more "\n" (any " ") (one-or-more not-newline)))
             line-end))
   :modes (text-mode markdown-mode gfm-mode))
+
 (add-to-list 'flycheck-checkers 'proselint)
+
+(provide 'flycheck-proselint)
+
+;;; flycheck-proselint.el ends here

--- a/plugins/flycheck/flycheck-proselint.el
+++ b/plugins/flycheck/flycheck-proselint.el
@@ -12,10 +12,14 @@
 ;; authors in the form of a linter for prose.
 ;;
 ;; This package provides a proselint checker for flycheck.
-;;
-;; To activate automatically, add to your .emacs, e.g.:
-;;   (add-hook 'markdown-mode-hook #'flycheck-mode)
-;;   (add-hook 'text-mode-hook #'flycheck-mode)
+
+;;; Usage:
+
+;; (eval-after-load 'flycheck
+;;   '(add-hook 'flycheck-mode-hook #'flycheck-proselint-setup))
+;; (add-hook 'text-mode-hook #'flycheck-mode)
+;; (add-hook 'markdown-mode-hook #'flycheck-mode)
+;; ...
 
 ;;; Code:
 
@@ -32,7 +36,10 @@
             line-end))
   :modes (text-mode markdown-mode gfm-mode))
 
-(add-to-list 'flycheck-checkers 'proselint)
+;;###autoload
+(defun flycheck-proselint-setup ()
+  "Add proselist to list of flycheck checkers."
+  (add-to-list 'flycheck-checkers 'proselint))
 
 (provide 'flycheck-proselint)
 

--- a/plugins/flycheck/flycheck-proselint.el
+++ b/plugins/flycheck/flycheck-proselint.el
@@ -1,4 +1,4 @@
-;;; flycheck-proselint.el --- a flycheck linter for prose
+;;; flycheck-proselint.el --- A flycheck linter for prose
 
 ;; Version: 0.8.0
 ;; Package-Requires: ((flycheck "1"))
@@ -7,8 +7,8 @@
 
 ;;; Commentary:
 
-;; proselint's goal is to aggregate knowledge about best practices in
-;; writing and to make that knowledge immediately accessible to all
+;; The goal of proselint is to aggregate knowledge about best practices
+;; in writing and to make that knowledge immediately accessible to all
 ;; authors in the form of a linter for prose.
 ;;
 ;; This package provides a proselint checker for flycheck.

--- a/plugins/flycheck/flycheck-proselint.el
+++ b/plugins/flycheck/flycheck-proselint.el
@@ -32,6 +32,7 @@
   :error-patterns
   ((warning line-start (file-name) ":" line ":" column ": "
             (id (one-or-more (not (any " "))))
+            " "
             (message (one-or-more not-newline)
                      (zero-or-more "\n" (any " ") (one-or-more not-newline)))
             line-end))

--- a/plugins/flycheck/tests/sample
+++ b/plugins/flycheck/tests/sample
@@ -1,0 +1,2 @@
+Painting colour on color
+It happened at 7 am.

--- a/plugins/flycheck/tests/test-flycheck-proselint.el
+++ b/plugins/flycheck/tests/test-flycheck-proselint.el
@@ -1,0 +1,58 @@
+(require 'flycheck-buttercup)
+(require 'flycheck-ert)
+(require 'flycheck-proselint)
+(require 'markdown-mode)
+
+(add-hook 'markdown-mode-hook #'flycheck-mode)
+(add-hook 'text-mode-hook #'flycheck-mode)
+(add-hook 'message-mode-hook #'flycheck-mode)
+(eval-after-load 'flycheck
+  '(add-hook 'flycheck-mode-hook #'flycheck-proselint-setup))
+
+(describe "Language English"
+    (describe "flycheck-proselint"
+        (it "parses example proselint output"
+            (let ((output "demo.md:11:5: dates_times.dates Apostrophes aren't needed for decades.
+demo.md:13:17: dates_times.dates When specifying a date range, write 'from X to Y'.
+demo.md:163:2: typography.symbols.copyright (c) is a goofy alphabetic approximation, use the symbol ©.
+"))
+              (with-temp-buffer
+                (expect
+                 (flycheck-parse-output output 'proselint (current-buffer))
+                 :to-be-equal-flycheck-errors
+                 (list
+                  (flycheck-error-new-at
+                   11 5 'warning
+                   "Apostrophes aren't needed for decades."
+                   :id "dates_times.dates"
+                   :checker 'proselint
+                   :buffer (current-buffer)
+                   :filename "demo.md")
+                  (flycheck-error-new-at
+                   13 17 'warning
+                   "When specifying a date range, write 'from X to Y'."
+                   :id "dates_times.dates"
+                   :checker 'proselint
+                   :buffer (current-buffer)
+                   :filename "demo.md")
+                  (flycheck-error-new-at
+                   163 2 'warning
+                   "(c) is a goofy alphabetic approximation, use the symbol ©."
+                   :id "typography.symbols.copyright"
+                   :checker 'proselint
+                   :buffer (current-buffer)
+                   :filename "demo.md"))))))
+
+        (it "activates in appropriate major modes"
+            (expect (flycheck-ert-should-syntax-check
+                     "tests/sample"
+                     '(text-mode markdown-mode gfm-mode message-mode)
+                     '(1 10 warning
+                         "Inconsistent spelling of 'color' (vs. 'colour')."
+                         :id "consistency.spelling"
+                         :checker proselint)
+                     '(2 16 warning
+                         "With lowercase letters, the periods are standard."
+                         :id "dates_times.am_pm.lowercase_periods"
+                         :checker proselint))
+                    :to-be nil))))


### PR DESCRIPTION
This scaffolding turns `flycheck-proselint.el` into an Emacs package, which will enable it to be included in package repositories such as [MELPA](https://melpa.org/) for easy installation.

This fixes #527.

Once this is done, I will submit the following recipe to MELPA to get the package included in their repository:
```elisp
(flycheck-proselint
 :fetcher github
 :repo "amperser/proselint"
 :files ("plugins/flycheck/flycheck-proselint.el"
         "README.md"
         "LICENSE.md"))
```