### PR TITLE
Fix one-off column offset with existence_check

### DIFF
--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -320,7 +320,7 @@ def existence_check(text, list, err, msg, ignore_case=True,
         flags = flags | re.DOTALL
 
     if require_padding:
-        regex = u"(?:^|\W){}[\W$]"
+        regex = u"(^|\W){}([\W$])"
     else:
         regex = u"{}"
 
@@ -335,9 +335,17 @@ def existence_check(text, list, err, msg, ignore_case=True,
     rx = "|".join(regex.format(w) for w in list)
     for m in re.finditer(rx, text, flags=flags):
         txt = m.group(0).strip()
+        start = m.start() + offset
+        end = m.end() + offset
+        if require_padding:
+            startpad_len = len(m.group(1)) if m.group(1) else 0
+            start += startpad_len
+            endpad_len = len(m.group(2)) if m.group(2) else 0
+            end -= (startpad_len + endpad_len)
+
         errors.append((
-            m.start() + 1 + offset,
-            m.end() + offset,
+            start,
+            end,
             err,
             msg.format(txt),
             None))

--- a/tests/test_dates_times_dates.py
+++ b/tests/test_dates_times_dates.py
@@ -70,7 +70,9 @@ class TestCheck(Check):
         assert chk.check_month_year_comma(
             "It happened in August 2008.") == []
         assert chk.check_month_year_comma(
-            "It happened in August, 2008.") != []
+            "It happened in August, 2008.") == [(
+                15, 26, 'dates_times.dates',
+                'When specifying a month and year, no comma is needed.', None)]
 
     def test_smoke_check_month_of_year(self):
         """Basic smoke test.

--- a/tests/test_mixed_metaphors.py
+++ b/tests/test_mixed_metaphors.py
@@ -27,5 +27,8 @@ class TestCheck(Check):
         """Basic smoke test for check_misc."""
         assert chk.check_misc(
             """Smoke phrase with nothing flagged.""") == []
-        assert chk.check_misc(
-            """Writing tests is not rocket surgery.""") != []
+        assert (chk.check_misc(
+            """Writing tests is not rocket surgery.""") == [(
+                17, 36, 'mixed_metaphors.misc.misc',
+                "Mixed metaphor. Try 'not rocket science'.",
+                'not rocket science')])

--- a/tests/test_typography_symbols.py
+++ b/tests/test_typography_symbols.py
@@ -18,7 +18,10 @@ class TestCheck(Check):
 
     def test_ellipsis(self):
         """Find ... in a string."""
-        assert chk.check_ellipsis("""The long and winding road...""")
+        errors = chk.check_ellipsis("""The long and winding road...""")
+        assert errors == [(
+            25, 28, 'typography.symbols.ellipsis',
+            "'...' is an approximation, use the ellipsis symbol '…'.", None)]
 
     def test_copyright(self):
         """Find a (c) or (C) in a string."""


### PR DESCRIPTION
When require_padding was not used (or it is at the beginning of a line),
columns were off by 1.

This patch adds/substracts the matched subgroup conditionally.

This could use more tests in general - none was failing with initial (wrong) changes in this area.

I've tried to use `\b` in the pattern instead, but that failed for/with `proselint/checks/misc/currency.py`.