### PR TITLE
Remove unnecessary #! lines

### DIFF
--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 """Command line utility for proselint."""

--- a/proselint/score.py
+++ b/proselint/score.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """Compute the lintscore on the corpus."""

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """General-purpose tools shared across linting checks."""


### PR DESCRIPTION
`rpmlint` is unhappy because these files are not executable but contain `#!` lines suggesting that they should be.