### PR TITLE
small update find_packages() to exclude tests directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(
     author='Amperser Labs',
     author_email='hello@amperser.com',
     license='BSD',
-    packages=find_packages(),
+    packages=find_packages(
+        exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_data={'': ['demo.md', '.proselintrc']},
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
Based on #704 I've made an update to `find_packages()` in setup.py to exclude all mention of tests. 