### PR TITLE
Enable unicode_literals for checks.links.broken

### DIFF
--- a/proselint/checks/links/broken.py
+++ b/proselint/checks/links/broken.py
@@ -13,6 +13,7 @@ categories: writing
 Check that links are not broken.
 
 """
+from __future__ import unicode_literals
 from proselint.tools import memoize
 from future import standard_library
 import re


### PR DESCRIPTION
This makes `\uXXXX` escape sequences in the regular expression work in Python 2.

Fixes #672