### PR TITLE
Add Python 3.6, drop unsupported 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 - '2.7'
 - '3.4'
 - '3.5'
+- '3.6'
 before_install:
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > emacs-version-manager-travis.sh && source ./emacs-version-manager-travis.sh
   - evm install $EVM_EMACS --use --skip
@@ -68,4 +69,4 @@ deploy:
     tags: true
     repo: amperser/proselint
     branch: master
-    python: 3.5
+    python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 language: python
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
 before_install:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install proselint
 - [x] [Phabricator's `arc` CLI](https://github.com/google/arc-proselint) (thanks to [Jeff Verkoeyen](https://github.com/jverkoey))
 - [x] [Danger](https://github.com/dbgrandi/danger-prose) (thanks to [David Grandinetti](https://github.com/dbgrandi) and [Orta Therox](https://github.com/orta))
 - [x] [Visual Studio Code](https://github.com/ppeszko/vscode-proselint) (thanks to [Patryk Peszko](https://github.com/ppeszko))
-- [x] [coala](https://github.com/coala-analyzer/bear-docs/blob/master/docs/ProseLintBear.rst) (thanks to the [coala Development Group](https://github.com/coala-analyzer))  
+- [x] [coala](https://github.com/coala-analyzer/bear-docs/blob/master/docs/ProseLintBear.rst) (thanks to the [coala Development Group](https://github.com/coala-analyzer))
 
 ### Usage
 
@@ -228,7 +228,7 @@ Automated tests are included in the `proselint/tests` directory. To run these te
 cd tests/
 nosetests
 ```
-and watch the output. Nose is compatible with Python versions 2.7, 3.3, 3.4 and 3.5.
+and watch the output. Nose is compatible with Python versions 2.7, 3.4 and 3.5.
 
 All automated tests in `tests/` are run as part of each submitted pull request, including newly added tests.
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Automated tests are included in the `proselint/tests` directory. To run these te
 cd tests/
 nosetests
 ```
-and watch the output. Nose is compatible with Python versions 2.7, 3.4 and 3.5.
+and watch the output. Nose is compatible with Python versions 2.7, 3.4, 3.5 and 3.6.
 
 All automated tests in `tests/` are run as part of each submitted pull request, including newly added tests.
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,14 @@ setup(
     author='Amperser Labs',
     author_email='hello@amperser.com',
     license='BSD',
+    classifiers=[
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+    ],
     packages=find_packages(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_data={'': ['demo.md', '.proselintrc']},


### PR DESCRIPTION
## Reasons for dropping 3.3

* https://en.wikipedia.org/wiki/CPython#Version_history
* pip 10 will deprecate Python 3.3 support, pip 11 won't support it (https://github.com/pypa/pip/issues/3796)
* Very little PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796
