### PR TITLE
Make proselint compliant XDG spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ This will return a list of suggestions:
 
 ### Checks
 
-You can disable any of the checks by modifying `~/.proselintrc`:
+You can disable any of the checks by modifying `$XDG_CONFIG_HOME/proselint/config`. If `$XDG_CONFIG_HOME` is not set or empty, `~/.config/proselint/config` will be used.
+Additionally for compatible reason, the legacy configuration `~/.proselintrc` will be used if `$XDG_CONFIG_HOME/proselint/config` does not exist.
 
 ```json
 {

--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -49,7 +49,6 @@ def clear_cache():
     # see issue #624
     _delete_compiled_python_files()
     _delete_cache()
-    _create_home_cache()
 
 
 def _delete_compiled_python_files():
@@ -67,14 +66,6 @@ def _delete_cache():
     proselint_cache = os.path.join("proselint", "cache")
     try:
         shutil.rmtree(proselint_cache)
-    except OSError:
-        pass
-
-
-def _create_home_cache():
-    """Create a cache in the users 'HOME' directory."""
-    try:
-        os.makedirs(os.path.join(os.path.expanduser("~"), ".proselint"))
     except OSError:
         pass
 

--- a/tests/test_clear_cache.py
+++ b/tests/test_clear_cache.py
@@ -140,27 +140,3 @@ class Test__delete_cache(unittest.TestCase):
     def test_on_oserror(self, mock_rmtree):
         """Ignore if general OSError."""
         cl._delete_cache()
-
-
-class Test_create_home_cache(unittest.TestCase):
-    """proselint.command_line._create_home_cache()."""
-
-    def setUp(self):
-        """Init common data."""
-        self.cache_path = os.path.join(os.path.expanduser("~"), ".proselint")
-
-    @mock.patch('os.makedirs')
-    def test_makedir(self, mock_makedir):
-        """correct directory is used."""
-        cl._create_home_cache()
-        mock_makedir.assert_called_with(self.cache_path)
-
-    @mock.patch('os.makedirs', side_effect=OSError)
-    def test_on_oserror(self, mock_rmtree):
-        """Ignore if general OSError."""
-        cl._create_home_cache()
-
-    @mock.patch('os.makedirs', side_effect=PermissionError)
-    def test__no_permission(self, mock_rmtree):
-        """Ignore if unable to delete."""
-        cl._create_home_cache()


### PR DESCRIPTION
The configuration file is now set as `$XDG_CONFIG_HOME/proselint/config`.
If `$XDG_CONFIG_HOME` is not set or empty, `~/.config/proselint/config`
will be used. Additionally for compatible reason, the legacy configuration
`~/.proselintrc` will be used if `$XDG_CONFIG_HOME/proselint/config`
does not exist.

Similarly, the cache location is set as `$XDG_CACHE_HOME/proselint`.
If `$XDG_CACHE_HOME` is not set or empty, `~/.cache/proselint` will
be used. It will also automatically migrate the legacy cache
`~/.proselint` to the new location.

Finally, remove the function `_create_home_cache()`, which is used in
`proselint --clean`, since the cache directory will be automatically
created and we have changed the cache location.

Fixes #747.