### PR TITLE
Fix typo in README closes #780

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Additionally for compatible reason, the legacy configuration `~/.proselintrc` wi
 | `spelling.em_im_en_in` | -em vs. -im and -en vs. -in |
 | `spelling.er_or` | -er vs. -or |
 | `spelling.in_un` | in- vs. un- |
-| `spelling.misc` | Spelling words corectly |
+| `spelling.misc` | Spelling words correctly |
 | `security.credit_card` | Keeping credit card numbers secret |
 | `security.password` | Keeping passwords secret |
 | `sexism.misc` | Avoiding sexist language |


### PR DESCRIPTION
This fixes a spelling mistake in the README.