### PR TITLE
use click testing for cli unit tests

### DIFF
--- a/tests/_test_version.py
+++ b/tests/_test_version.py
@@ -1,10 +1,8 @@
 """Test version number."""
-from __future__ import absolute_import
-from __future__ import print_function
-
 from .check import Check
+from click.testing import CliRunner
 from proselint.version import __version__
-import subprocess
+from proselint.command_line import proselint
 
 
 class TestCheck(Check):
@@ -14,5 +12,7 @@ class TestCheck(Check):
 
     def test_version(self):
         """Make sure the version number is correct."""
-        out = subprocess.check_output(["proselint", "--version"])
-        assert out.decode('utf-8') == __version__ + "\n"
+        runner = CliRunner()
+
+        output = runner.invoke(proselint, "--version")
+        assert __version__ in output.stdout

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,5 +1,0 @@
-"""Run the demo."""
-
-import subprocess
-
-subprocess.call(["proselint", "--debug", ">/dev/null"], shell=True)

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -1,21 +1,24 @@
 """Check that the CLI returns the appropriate exit code."""
 
-import subprocess
+from .check import Check
+from click.testing import CliRunner
+from proselint.command_line import proselint
 
 
-def test_exit_code_demo():
-    """Ensure that linting the demo returns an exit code of 1."""
-    try:
-        subprocess.check_output(["python", "-m", "proselint", "--demo"])
+class TestExitCodes(Check):
+    """Test class for CLI exit codes"""
 
-    except subprocess.CalledProcessError as grepexc:
-        assert(grepexc.returncode == 1)
+    __test__ = True
 
+    def setUp(self):
+        self.runner = CliRunner()
 
-def test_exit_code_version():
-    """Ensure that getting the version returns an exit code of 0."""
-    try:
-        subprocess.check_output(["python", "-m", "proselint", "--version"])
+    def test_exit_code_demo(self):
+        """Ensure that linting the demo returns an exit code of 1."""
+        output = self.runner.invoke(proselint, "--demo")
+        assert output.exit_code == 1
 
-    except subprocess.CalledProcessError:
-        assert(False)
+    def test_exit_code_version(self):
+        """Ensure that getting the version returns an exit code of 0."""
+        output = self.runner.invoke(proselint, "--version")
+        assert output.exit_code == 0

--- a/tests/test_illegal_chars.py
+++ b/tests/test_illegal_chars.py
@@ -1,30 +1,23 @@
 """Check that the CLI can handle invalid characters."""
 
-import os.path as pth
-import subprocess
+from .check import Check
+from click.testing import CliRunner
+from os.path import dirname, abspath, join
+from proselint.command_line import proselint
 
 
-def test_invalid_characters():
-    """Ensure that a file with illegal characters does not break us."""
-    output = ""
-    curr_dir = pth.dirname(pth.abspath(__file__))
-    test_file = pth.join(curr_dir, "illegal-chars.txt")
-    try:
-        # TODO: refactor CLI function
-        # We only print out exception text and continue after printing a trace,
-        # so the only way (currently) to test for failure is to look for the
-        # exception text. Refactoring the command line function would let us
-        # write better tests (one day).
-        output = str(subprocess.check_output(
-            ["python", "-m", "proselint", test_file],
-            stderr=subprocess.STDOUT
-        ))
-    except subprocess.CalledProcessError as e:
-        # Non-zero return codes are OK, but what did we catch?
-        print("Non-zero return value: will proceed. %s" % e)
-        output += str(e.output)
-    except Exception:
-        assert(not "Unknown Exception Occurred")
+class TestInvalidCharacters(Check):
+    """Test class for testing invalid characters on the CLI"""
 
-    assert("UnicodeDecodeError" not in output)  # Failed to process the file
-    assert("FileNotFoundError" not in output)   # Failed to find our test file
+    __test__ = True
+
+    def test_invalid_characters(self):
+        """Ensure that a file with illegal characters does not break us."""
+        curr_dir = dirname(abspath(__file__))
+        test_file = join(curr_dir, "illegal-chars.txt")
+        runner = CliRunner()
+
+        output = runner.invoke(proselint, test_file)
+
+        assert "UnicodeDecodeError" not in output.stdout
+        assert "FileNotFoundError" not in output.stdout


### PR DESCRIPTION
## This relates to...

N/A.

## Rationale

Prior to this, tests for the CLI would use `subprocess`. This was
inefficient and prevented us from acquiring coverage information.

## Changes

All tests were converted to use `click.testing` rather than
`subprocess`.

### Features

N/A.

### Bug Fixes

N/A.

### Breaking Changes and Deprecations

N/A.
