### PR TITLE
Allow including / excluding individual checks by key

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,13 @@ This will return a list of suggestions:
 You can disable any of the checks by modifying `$XDG_CONFIG_HOME/proselint/config`. If `$XDG_CONFIG_HOME` is not set or empty, `~/.config/proselint/config` will be used.
 Additionally for compatible reason, the legacy configuration `~/.proselintrc` will be used if `$XDG_CONFIG_HOME/proselint/config` does not exist.
 
+You can disable either entire sets of tests or individual tests from within a set through the config file.
+
 ```json
 {
   "checks": {
-    "typography.diacritical_marks": false
+    "typography.diacritical_marks": false,
+    "typography.symbol.ellipsis": false
   }
 }
 ```

--- a/tests/test_get_checks.py
+++ b/tests/test_get_checks.py
@@ -1,0 +1,47 @@
+"""Tests for annotations.misc check."""
+from __future__ import absolute_import
+
+from .check import Check
+
+from proselint.tools import get_checks
+
+
+class TestCheck(Check):
+    """The test class for annotations.misc."""
+
+    __test__ = True
+
+    def test_exclude(self):
+        full_checks = get_checks({
+            'checks': {
+                'typography.symbols': True,
+            }
+        })
+
+        skip_ellipsis = get_checks({
+            'checks': {
+                'typography.symbols': True,
+                'typography.symbols.ellipsis': False,
+            }
+        })
+
+        assert len(full_checks) - 1 == len(skip_ellipsis)
+
+    def test_only(self):
+        checks = get_checks({
+            'checks': {
+                'typography.symbols': False,
+                'typography.symbols.ellipsis': True,
+            }
+        })
+
+        assert len(checks) == 1
+
+    def test_implicit_only(self):
+        checks = get_checks({
+            'checks': {
+                'typography.symbols.ellipsis': True,
+            }
+        })
+
+        assert len(checks) == 1


### PR DESCRIPTION
This pull requests allows the end user to include or exclude individual tests as part of the config file. I was using this to lint a file where my markdown pipeline automatically converted ellipsis and quotes to their nicer html entity equivalents. Prior to this pull request, I could only disable the entire typography.symbols suite but my pipeline would not automatically convert a `(c)` so I didn't want to disable the whole suite.

Resolves #729. Resolves #491. Resolves #1091.