### PR TITLE
Fix incorrectly placed mondegreen

### DIFF
--- a/proselint/checks/mondegreens/misc.py
+++ b/proselint/checks/mondegreens/misc.py
@@ -25,7 +25,7 @@ def check(text):
     list = [
         ["a girl with kaleidoscope eyes", ["a girl with colitis goes by"]],
         ["a partridge in a pear tree",    ["a part-red gingerbread tree"]],
-        ["attorney and not a republic",   ["attorney and notary public"]],
+        ["attorney and notary public",    ["attorney and not a republic"]],
         ["beck and call",                 ["beckon call"]],
         ["for all intents and purposes",  ["for all intensive purposes"]],
         ["laid him on the green",         ["Lady Mondegreen"]],


### PR DESCRIPTION
The file labelled `"attorney and notary public"` as a mondegreen, and proposes `"attorney and not a republic"` as the preferred form, which was incorrect. This change swaps them around to fix it.