### PR TITLE
Fix race condition in cache directory creation

### DIFF
--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -108,7 +108,7 @@ def memoize(f):
             os.rename(legacy_cache_dirname, cache_dirname)
         # Create the cache if it does not already exist.
         else:
-            os.makedirs(cache_dirname)
+            os.makedirs(cache_dirname, exist_ok=True)
 
     cache_filename = f.__module__ + "." + f.__name__
     cachepath = os.path.join(cache_dirname, cache_filename)


### PR DESCRIPTION
If two instances of proselint are running concurrently for the first time, it is possible that both will fail the `cache_dirname` directory existence check. Both will try to create the directory, but one that attempts to create it after the other [will raise `FileExistsError`](https://docs.python.org/3/library/os.html#os.makedirs).

While this fixes the issue at hand, it would be great to have finer control over when the cache is used

Passing `exist_ok=True` will do nothing if the directory already exists. 