### PR TITLE
Allow individual checks to be disabled by user, per #1091

### DIFF
--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -151,14 +151,20 @@ def get_checks(options):
     """Extract the checks."""
     sys.path.append(proselint_path)
     checks = []
+
     check_names = [key for (key, val)
                    in list(options["checks"].items()) if val]
+    remove_subcheck_names = [key for (key, val)
+                             in list(options["checks"].items()) if not val and
+                             key.count('.') == 2]
 
     for check_name in check_names:
         module = importlib.import_module("checks." + check_name)
         for d in dir(module):
             if re.match("check", d):
-                checks.append(getattr(module, d))
+                subcheck_name = check_name + "." + d.replace("check_", "")
+                if subcheck_name not in remove_subcheck_names:
+                    checks.append(getattr(module, d))
 
     return checks
 


### PR DESCRIPTION
This is pursuant to issue #1091 — Creates list of individual subchecks which have been disabled by user in config file and then removes them from the list of checks to be executed. Each subcheck's function should start with 'check_'. The name of the check should also match the function.

For example: The subcheck typography.symbols.curly_quotes would be the function check_curly_quotes in typography.symbols.

I saw that some subchecks have slightly different function names and so these would need to be adjusted. An example is the subcheck typography.symbols.copyright, which is the function check_copyright_symbol in typography.symbols. To keep the tests running, I think this subcheck's name should be adjusted to typography.symbols.copyright_symbol.

This is my first pull request. I tried installing the requirements for pip from requirements.txt but it was unhappy about Flask-API. The tests were likewise unsuccessful even before I made any changes, and I'm not sure if Flask-API was the cause. I'm on Debian 10 if that makes any difference.

I ran the pep8 and pep257 style-checks before submitting.

Thank you.