### PR TITLE
fix: correct always-passing uncomparables

### DIFF
--- a/.github/workflows/ci-lint-test.yml
+++ b/.github/workflows/ci-lint-test.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     steps:

--- a/.github/workflows/ci-lint-test.yml
+++ b/.github/workflows/ci-lint-test.yml
@@ -44,6 +44,7 @@ jobs:
       matrix:
         python: [3.6, 3.7, 3.8, 3.9, pypy3]
         os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
     steps:
       - name: "[INIT] Checkout repository"
         uses: actions/checkout@v2

--- a/proselint/checks/uncomparables/misc.py
+++ b/proselint/checks/uncomparables/misc.py
@@ -45,11 +45,9 @@ One axiom of Standard Written English is that your reader is paying close
 attention and expects you to have done the same.
 """
 import re
-from proselint.tools import memoize
 import itertools
 
 
-@memoize
 def check(text):
     """Check the text."""
     err = "uncomparables.misc"
@@ -114,7 +112,7 @@ def check(text):
         ("more", "possible")  # FIXME
     ]
 
-    all = [r"\\b" + i[0] + r"\s" + i[1] + r"[\W$]" for i in itertools.product(
+    all = [i[0] + r"\s" + i[1] + r"[\W$]" for i in itertools.product(
            comparators, uncomparables) if i not in exceptions]
 
     occ = re.finditer("|".join(all), text.lower())

--- a/tests/check.py
+++ b/tests/check.py
@@ -32,9 +32,9 @@ class Check(TestCase):
 
         errors = []
         for text in lst:
-            errors.append(self.this_check.check(text))
+            errors += self.this_check.check(text)
 
-        return len(errors[0]) == 0
+        return len(errors) == 0
 
     def wpe_too_high(self):
         """Check whether the check is too noisy."""


### PR DESCRIPTION
- ci: remove fail-fast test matrix
- test: use concatenation instead of append and 1st index
- fix: patch always-passing uncomparables
- ci: remove pypy from testing
