### PR TITLE
test: add curly quotes test for typography

### DIFF
--- a/proselint/checks/typography/symbols.py
+++ b/proselint/checks/typography/symbols.py
@@ -79,13 +79,10 @@ def check_curly_quotes(text):
     u"""Use curly quotes, not straight quotes."""
     err = "typography.symbols.curly_quotes"
     msg = u'Use curly quotes “”, not straight quotes "".'
+    regex = r"\"[\w\s\d]+\""
 
-    list = [
-        [u"“ or ”", ['"']],
-    ]
-
-    return preferred_forms_check(
-        text, list, err, msg, ignore_case=False, max_errors=2)
+    return existence_check(
+        text, [regex], err, msg, max_errors=3, require_padding=False)
 
 # @memoize
 # def check_en_dash_separated_names(text):

--- a/tests/test_typography_symbols.py
+++ b/tests/test_typography_symbols.py
@@ -47,4 +47,7 @@ class TestCheck(Check):
 
     def test_curly_quotes(self):  # FIXME
         """Find "" quotes in a string."""
-        pass
+        assert chk.check_curly_quotes(
+            "\"This should produce an error\", he said.")
+        assert not chk.check_curly_quotes("But this should not.")
+        assert chk.check_curly_quotes("Alas, \"it should here too\".")

--- a/tests/test_typography_symbols.py
+++ b/tests/test_typography_symbols.py
@@ -51,3 +51,4 @@ class TestCheck(Check):
             "\"This should produce an error\", he said.")
         assert not chk.check_curly_quotes("But this should not.")
         assert chk.check_curly_quotes("Alas, \"it should here too\".")
+        assert not chk.check_curly_quotes("\"A singular should not, though.")


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Ensure that tests and linting pass.
-->

## This relates to...

The symbols typography check, specifically the curly quotes subcheck.
Prior to this PR it raised inapplicable false positives when matching
lone quotes instead of checking for pairs, and the test function for
it was missing.

## Changes

- fix(checks/typography): adjust curly quotes regex
- test: add curly quotes typography test

### Features

N/A.

### Bug Fixes

- Fixed a faulty matcher for the curly quotes typography check that
  would match any quotes instead of a pair.

### Breaking Changes and Deprecations


N/A.
