### PR TITLE
feat: implement project-wide proselintrc

### DIFF
--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -133,19 +133,18 @@ def proselint(paths=None, config=None, version=None, clean=None, debug=None,
         filepaths.append('-')
 
     for fp in filepaths:
-        try:
-            if fp == '-':
-                fp = '<stdin>'
-                f = sys.stdin
-            else:
-                f = click.open_file(
-                    fp, 'r', encoding="utf-8", errors="replace")
-            errors = lint(f, debug=debug, config_file_path=config)
-            num_errors += len(errors)
-            print_errors(fp, errors, output_json, compact=compact)
-        except Exception:
-            traceback.print_exc()
-            sys.exit(2)
+        if fp == '-':
+            fp = '<stdin>'
+            f = sys.stdin
+        else:
+            try:
+                f = click.open_file(fp, 'r', encoding="utf-8", errors="replace")
+            except Exception:
+                traceback.print_exc()
+                sys.exit(2)
+        errors = lint(f, debug=debug, config_file_path=config)
+        num_errors += len(errors)
+        print_errors(fp, errors, output_json, compact=compact)
 
     # Return an exit code
     close_cache_shelves()

--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -138,7 +138,8 @@ def proselint(paths=None, config=None, version=None, clean=None, debug=None,
             f = sys.stdin
         else:
             try:
-                f = click.open_file(fp, 'r', encoding="utf-8", errors="replace")
+                f = click.open_file(
+                    fp, 'r', encoding="utf-8", errors="replace")
             except Exception:
                 traceback.print_exc()
                 sys.exit(2)

--- a/proselint/command_line.py
+++ b/proselint/command_line.py
@@ -145,6 +145,7 @@ def proselint(paths=None, config=None, version=None, clean=None, debug=None,
             print_errors(fp, errors, output_json, compact=compact)
         except Exception:
             traceback.print_exc()
+            sys.exit(2)
 
     # Return an exit code
     close_cache_shelves()

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -185,6 +185,9 @@ def load_options(config_file_path=None):
         os.path.join(home_dir, '.proselintrc')
     ]
     if config_file_path:
+        if not os.path.isfile(config_file_path):
+            raise FileNotFoundError(
+                'Config file %s does not exist' % config_file_path)
         user_config_paths.insert(0, config_file_path)
 
     user_options = {}

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -187,7 +187,7 @@ def load_options(config_file_path=None):
     if config_file_path:
         if not os.path.isfile(config_file_path):
             raise FileNotFoundError(
-                'Config file %s does not exist' % config_file_path)
+                f"Config file {config_file_path} does not exist")
         user_config_paths.insert(0, config_file_path)
 
     user_options = {}

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -20,6 +20,7 @@ import dbm
 _cache_shelves = dict()
 proselint_path = os.path.dirname(os.path.realpath(__file__))
 home_dir = os.path.expanduser("~")
+cwd = os.getcwd()
 
 
 def close_cache_shelves():
@@ -179,6 +180,7 @@ def load_options(config_file_path=None):
             break
 
     user_config_paths = [
+        os.path.join(cwd, '.proselintrc'),
         os.path.join(_get_xdg_config_home(), 'proselint', 'config'),
         os.path.join(home_dir, '.proselintrc')
     ]

--- a/tests/test_config_flag.py
+++ b/tests/test_config_flag.py
@@ -22,7 +22,14 @@ def test_config_flag():
     output = subprocess.run(["python", "-m", "proselint", "--demo"],
                             stdout=subprocess.PIPE, encoding='utf-8')
     assert "uncomparables.misc" in output.stdout
+
     output = subprocess.run(["python", "-m", "proselint", "--demo", "--config",
                              "tests/test_config_flag_proselintrc"],
                             stdout=subprocess.PIPE, encoding='utf-8')
     assert "uncomparables.misc" not in output.stdout
+
+    output = subprocess.run(["python", "-m", "proselint", "--demo", "--config",
+                             "non_existing_file"],
+                            stderr=subprocess.PIPE, encoding='utf-8')
+    assert output.returncode == 2
+    assert 'FileNotFoundError' in output.stderr

--- a/tests/test_config_flag.py
+++ b/tests/test_config_flag.py
@@ -33,3 +33,10 @@ def test_config_flag():
                             stderr=subprocess.PIPE, encoding='utf-8')
     assert output.returncode == 1
     assert "FileNotFoundError" in output.stderr
+
+    output = subprocess.run(["python", "-m", "proselint", "--config",
+                             "tests/test_config_flag_proselintrc",
+                             "non_existent_file"],
+                            stderr=subprocess.PIPE, encoding='utf-8')
+    assert output.returncode == 2
+    assert "FileNotFoundError" in output.stderr

--- a/tests/test_config_flag.py
+++ b/tests/test_config_flag.py
@@ -1,6 +1,13 @@
 """Test user option overrides using --config and load_options"""
 import subprocess
-from proselint.tools import load_options
+from proselint.tools import deepmerge_dicts, load_options
+
+
+def test_deepmerge_dicts():
+    """Test deepmerge_dicts"""
+    d1 = {'a': 1, 'b': {'c': 2, 'd': 3}}
+    d2 = {'a': 2, 'b': {'c': 3, 'e': 4}}
+    assert deepmerge_dicts(d1, d2) == {'a': 2, 'b': {'c': 3, 'd': 3, 'e': 4}}
 
 
 def test_load_options_function():
@@ -8,14 +15,6 @@ def test_load_options_function():
     overrides = load_options("tests/test_config_flag_proselintrc")
     assert load_options()["checks"]["uncomparables.misc"]
     assert not overrides["checks"]["uncomparables.misc"]
-
-
-def test_load_fallbacks():
-    """Test load_options with a fallback path"""
-    fallbacks = load_options(None, ["tests/test_config_flag_proselintrc"])
-    assert not fallbacks["checks"]["uncomparables.misc"]
-    fallbacks = load_options(None, ["./.proselintrc"])
-    assert fallbacks["checks"]["uncomparables.misc"]
 
 
 def test_config_flag():

--- a/tests/test_config_flag.py
+++ b/tests/test_config_flag.py
@@ -1,6 +1,7 @@
 """Test user option overrides using --config and load_options"""
-import subprocess
+from click.testing import CliRunner
 from proselint.tools import deepmerge_dicts, load_options
+from proselint.command_line import proselint
 
 
 def test_deepmerge_dicts():
@@ -19,24 +20,18 @@ def test_load_options_function():
 
 def test_config_flag():
     """Test the --config CLI argument"""
-    output = subprocess.run(["python", "-m", "proselint", "--demo"],
-                            stdout=subprocess.PIPE, encoding='utf-8')
+    runner = CliRunner()
+
+    output = runner.invoke(proselint, "--demo")
     assert "uncomparables.misc" in output.stdout
 
-    output = subprocess.run(["python", "-m", "proselint", "--demo", "--config",
-                             "tests/test_config_flag_proselintrc"],
-                            stdout=subprocess.PIPE, encoding='utf-8')
+    output = runner.invoke(
+        proselint, "--demo --config tests/test_config_flag_proselintrc")
     assert "uncomparables.misc" not in output.stdout
 
-    output = subprocess.run(["python", "-m", "proselint", "--demo", "--config",
-                             "non_existent_file"],
-                            stderr=subprocess.PIPE, encoding='utf-8')
-    assert output.returncode == 1
-    assert "FileNotFoundError" in output.stderr
+    output = runner.invoke(proselint, "--demo --config non_existent_file")
+    assert output.exit_code == 1
+    assert "FileNotFoundError" == output.exc_info[0].__name__
 
-    output = subprocess.run(["python", "-m", "proselint", "--config",
-                             "tests/test_config_flag_proselintrc",
-                             "non_existent_file"],
-                            stderr=subprocess.PIPE, encoding='utf-8')
-    assert output.returncode == 2
-    assert "FileNotFoundError" in output.stderr
+    output = runner.invoke(proselint, "non_existent_file")
+    assert output.exit_code == 2

--- a/tests/test_config_flag.py
+++ b/tests/test_config_flag.py
@@ -29,7 +29,7 @@ def test_config_flag():
     assert "uncomparables.misc" not in output.stdout
 
     output = subprocess.run(["python", "-m", "proselint", "--demo", "--config",
-                             "non_existing_file"],
+                             "non_existent_file"],
                             stderr=subprocess.PIPE, encoding='utf-8')
-    assert output.returncode == 2
-    assert 'FileNotFoundError' in output.stderr
+    assert output.returncode == 1
+    assert "FileNotFoundError" in output.stderr


### PR DESCRIPTION
Hey again :wave: 

This PR makes proselint pick up `.proselintrc` file in the current working directory, i.e. project specific config files. Also included some refactoring and error reporting.

Resolves https://github.com/amperser/proselint/issues/1112.