### PR TITLE
use regex for lexical illusions

### DIFF
--- a/proselint/checks/lexical_illusions/misc.py
+++ b/proselint/checks/lexical_illusions/misc.py
@@ -21,11 +21,8 @@ def check(text):
     """Check the text."""
     err = "lexical_illusions.misc"
     msg = u"There's a lexical illusion here: a word is repeated."
+    regex = r"\b(\w+)(\b\s\1)+"
+    exceptions = [r"^had had$", r"^that that$"]
 
-    list = [
-        r"the\sthe",
-        r"am\sam",
-        r"has\shas"
-    ]
-
-    return existence_check(text, list, err, msg)
+    return existence_check(text, [regex], err, msg, exceptions=exceptions,
+                           require_padding=False)

--- a/tests/test_lexical_illusions.py
+++ b/tests/test_lexical_illusions.py
@@ -20,3 +20,4 @@ class TestCheck(Check):
         """Basic smoke test for lexical_illusions.misc."""
         assert self.passes("""Smoke phrase with nothing flagged.""")
         assert not self.passes("""Paris in the the springtime.""")
+        assert self.passes("""And he's gone, gone with the breeze""")

--- a/tests/test_lexical_illusions.py
+++ b/tests/test_lexical_illusions.py
@@ -18,6 +18,9 @@ class TestCheck(Check):
 
     def test_smoke(self):
         """Basic smoke test for lexical_illusions.misc."""
-        assert self.passes("""Smoke phrase with nothing flagged.""")
-        assert not self.passes("""Paris in the the springtime.""")
-        assert self.passes("""And he's gone, gone with the breeze""")
+        assert self.passes("Smoke phrase with nothing flagged.")
+        assert not self.passes("Paris in the the springtime.")
+        assert self.passes("And he's gone, gone with the breeze")
+        assert self.passes("You should know that that sentence wasn't wrong.")
+        assert self.passes("She had had dessert on the balcony.")
+        assert not self.passes("You should know that that that was wrong.")


### PR DESCRIPTION
## This relates to...

The usage of regular expressions rather than simple matches for
`lexical_illusions.misc`.

## Rationale

Prior to this, the lexical illusions check would only catch
3 different lexical illusions, and always in pairs of two rather than
flagging the entire strand. This is inefficient, and does not catch
many lexical illusions at all.

## Changes

- `lexical_illusions.misc` now uses regex
- `lexical_illusions.misc` now reports entire strands instead of many word pairs
- `lexical_illusions.misc` reports all lexical illusions except for `that that`
  and `had had`

### Features

N/A.

### Bug Fixes

N/A.

### Breaking Changes and Deprecations

N/A.
