### PR TITLE
fix(tools): correct potentially unbound return for line_and_column

### DIFF
--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -216,11 +216,13 @@ def errors_to_json(errors):
 def line_and_column(text, position):
     """Return the line number and column of a position in a string."""
     position_counter = 0
-    for idx_line, line in enumerate(text.splitlines(True)):
+    line_no = 0
+    for line in text.splitlines(True):
         if (position_counter + len(line.rstrip())) >= position:
-            return (idx_line, position - position_counter)
-        else:
-            position_counter += len(line)
+            break
+        position_counter += len(line)
+        line_no += 1
+    return (line_no, position - position_counter)
 
 
 def lint(input_file, debug=False, config_file_path=None):


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Ensure that tests and linting pass.
-->

## This relates to...

The `line_and_columns` function of `proselint/tools.py`.

## Rationale

The return type of this function is currently potentially unbound. As a result
of this, Python and various ecosystem tools are unable to determine its return
type accurately, even though we know it will never return an unbound.

## Changes

- perf: prefer incrementation to enumeration
- fix(tools): correct return type for line_and_columns

### Features

N/A.

### Bug Fixes

N/A.

### Breaking Changes and Deprecations

N/A.
