### PR TITLE
add exceptions for existence_check

### DIFF
--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -327,8 +327,8 @@ def preferred_forms_check(text, list, err, msg, ignore_case=True, offset=0,
 def existence_check(text, list, err, msg, ignore_case=True,
                     str=False, max_errors=float("inf"), offset=0,
                     require_padding=True, dotall=False,
-                    excluded_topics=None, join=False):
-    """Build a checker that blacklists certain words."""
+                    excluded_topics=None, exceptions=[], join=False):
+    """Build a checker that prohibits certain words or phrases."""
     flags = 0
 
     msg = " ".join(msg.split())
@@ -358,6 +358,8 @@ def existence_check(text, list, err, msg, ignore_case=True,
     rx = "|".join(regex.format(w) for w in list)
     for m in re.finditer(rx, text, flags=flags):
         txt = m.group(0).strip()
+        if any([re.search(exception, txt) for exception in exceptions]):
+            continue
         errors.append((
             m.start() + 1 + offset,
             m.end() + offset,

--- a/tests/test_existence_check.py
+++ b/tests/test_existence_check.py
@@ -50,3 +50,14 @@ class TestCheck(Check):
         assert chk("abc is easy as 123", self.L, self.err, self.msg) != []
         assert chk(u'abc is easy as 123', self.L, self.err, self.msg) != []
         assert chk(u"abc is easy as 123", self.L, self.err, self.msg) != []
+
+    def test_exceptions(self):
+        """Test that existence_check does not report excluded phrases"""
+        regex = [r"\b(\w+)\b\s\1"]
+        no = ["should should"]
+        errs = chk("should should flag flag.", regex, "", "",
+                   require_padding=False)
+        assert len(errs) == 2
+        errs = chk("should should flag flag.", regex, "", "", exceptions=no,
+                   require_padding=False)
+        assert len(errs) == 1

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from .check import Check
 
-from proselint.tools import lint as lint
+from proselint.tools import lint, existence_check
 
 
 class TestLint(Check):


### PR DESCRIPTION
## This relates to...

[A comment on #1174](https://github.com/amperser/proselint/pull/1174#issuecomment-858177692)

## Rationale

Prior to this, there was no way to make exceptions for regexes passed
to existence_check. The only option was to use negative lookbehinds
or lookaheads, which are both performance expensive and do not work
very well for multiple exceptions.

## Changes

- An `exceptions` argument was added to `tools.existence_check`

### Features

- Regex exceptions can now be made for `tools.existence_check`

### Bug Fixes

N/A.

### Breaking Changes and Deprecations

N/A.
