### PR TITLE
feat: convert meta-checks to decorators

### DIFF
--- a/proselint/checks/typography/exclamation.py
+++ b/proselint/checks/typography/exclamation.py
@@ -12,9 +12,7 @@ categories: writing
 Too much yelling.
 
 """
-import re
-
-from proselint.tools import existence_check, max_errors, memoize
+from proselint.tools import existence_check, max_errors, memoize, ppm_threshold
 
 
 @max_errors(1)
@@ -30,6 +28,7 @@ def check_repeated_exclamations(text):
                            ignore_case=False, dotall=True)
 
 
+@ppm_threshold(30)
 @memoize
 def check_exclamations_ppm(text):
     """Make sure that the exclamation ppm is under 30."""
@@ -38,13 +37,4 @@ def check_exclamations_ppm(text):
 
     regex = r"\w!"
 
-    count = len(re.findall(regex, text))
-    num_words = len(text.split(" "))
-
-    ppm = (count*1.0 / num_words) * 1e6
-
-    if ppm > 30 and count > 1:
-        loc = re.search(regex, text).start() + 1
-        return [(loc, loc+1, err, msg, ".")]
-    else:
-        return []
+    return existence_check(text, [regex], err, msg, require_padding=False)

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -391,6 +391,7 @@ def truncate_errors(errors, limit=float("inf")):
 
     return errors
 
+
 def ppm_threshold(threshold):
     """Decorate a check to error if the PPM threshold is surpassed."""
     def wrapped(f):
@@ -410,6 +411,7 @@ def threshold_check(errors, threshold, length):
         if ppm >= threshold and errcount >= 1:
             return [errors[0]]
     return []
+
 
 def is_quoted(position, text):
     """Determine if the position in the text falls within a quote."""

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -391,6 +391,25 @@ def truncate_errors(errors, limit=float("inf")):
 
     return errors
 
+def ppm_threshold(threshold):
+    """Decorate a check to error if the PPM threshold is surpassed."""
+    def wrapped(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            return threshold_check(f(*args, **kwargs), threshold, len(args[0]))
+        return wrapper
+    return wrapped
+
+
+def threshold_check(errors, threshold, length):
+    """Check that returns an error if the PPM threshold is surpassed."""
+    if length > 0:
+        errcount = len(errors)
+        ppm = (errcount / length) * 1e6
+
+        if ppm >= threshold and errcount >= 1:
+            return [errors[0]]
+    return []
 
 def is_quoted(position, text):
     """Determine if the position in the text falls within a quote."""


### PR DESCRIPTION
## This relates to...

Adding threshold checks. This blocks #802. This is blocked by #1217 and #1218.

## Rationale

This is useful for situations such as in
`checks.typography.exclamation.30ppm` where a PPM threshold metric
determines whether to raise an error or not.

## Changes

- Add `tools.threshold_check`
- Convert `checks.typography.exclamation` to use `threshold_check`

### Features

- Add `tools.threshold_check`

### Bug Fixes

N/A.

### Breaking Changes and Deprecations

N/A.