### PR TITLE
fix: correct false positives for lexical illusion regex

### DIFF
--- a/proselint/checks/lexical_illusions/misc.py
+++ b/proselint/checks/lexical_illusions/misc.py
@@ -21,7 +21,7 @@ def check(text):
     """Check the text."""
     err = "lexical_illusions.misc"
     msg = u"There's a lexical illusion here: a word is repeated."
-    regex = r"\b(\w+)(\b\s\1)+"
+    regex = r"\b(\w+)(\b\s\1)+\b"
     exceptions = [r"^had had$", r"^that that$"]
 
     return existence_check(text, [regex], err, msg, exceptions=exceptions,

--- a/tests/test_lexical_illusions.py
+++ b/tests/test_lexical_illusions.py
@@ -24,3 +24,6 @@ class TestCheck(Check):
         assert self.passes("You should know that that sentence wasn't wrong.")
         assert self.passes("She had had dessert on the balcony.")
         assert not self.passes("You should know that that that was wrong.")
+        assert self.passes("The practitioner's side")
+        assert self.passes("An antimatter particle")
+        assert self.passes("The theory")


### PR DESCRIPTION
Hotfix for #1191 