### PR TITLE
fix: make memoize safe for args/kwargs

### DIFF
--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -112,7 +112,8 @@ def memoize(f):
         tempargdict = inspect.getcallargs(f, *args, **kwargs)
 
         for item in list(tempargdict.items()):
-            signature += item[1].encode("utf-8")
+            if item[0] == "text":
+                signature += item[1].encode("utf-8")
 
         key = hashlib.sha256(signature).hexdigest()
         cache = _get_cache(cachepath)


### PR DESCRIPTION
## This relates to...

The addition of decorators to memoized checks. This blocks
\#1188.

## Rationale

Without this fix, memoization cannot be applied to decorated
functions, which is necessary to convert meta-checks [as
discussed](https://github.com/amperser/proselint/pull/1188#pullrequestreview-699458926).

## Changes

- fix bug where memoize raises an error for decorated
  functions

### Features

N/A.

### Bug Fixes

- fix bug where memoize raises an error for decorated
  functions

### Breaking Changes and Deprecations

N/A.
