### PR TITLE
refactor: convert max_errors to decorator

### DIFF
--- a/proselint/checks/cliches/hell.py
+++ b/proselint/checks/cliches/hell.py
@@ -12,9 +12,10 @@ categories: writing
 Never use the phrase 'all hell broke loose'.
 
 """
-from proselint.tools import existence_check, memoize
+from proselint.tools import existence_check, max_errors, memoize
 
 
+@max_errors(1)
 @memoize
 def check_repeated_exclamations(text):
     """Check the text."""
@@ -23,5 +24,4 @@ def check_repeated_exclamations(text):
 
     regex = r"all hell broke loose"
 
-    return existence_check(
-        text, [regex], err, msg, max_errors=1)
+    return existence_check(text, [regex], err, msg)

--- a/proselint/checks/misc/pretension.py
+++ b/proselint/checks/misc/pretension.py
@@ -12,9 +12,10 @@ categories: writing
 Never use the phrase 'all hell broke loose'.
 
 """
-from proselint.tools import existence_check, memoize
+from proselint.tools import existence_check, max_errors, memoize
 
 
+@max_errors(1)
 @memoize
 def check(text):
     """Check the text."""
@@ -28,4 +29,4 @@ def check(text):
         "judgmentally",
     ]
 
-    return existence_check(text, list, err, msg, max_errors=1)
+    return existence_check(text, list, err, msg)

--- a/proselint/checks/misc/suddenly.py
+++ b/proselint/checks/misc/suddenly.py
@@ -24,9 +24,10 @@ apparent in the action itself. For example, in “Suddenly, I don’t hate you
 anymore,” the “suddenly” substantially changes the way we think about the
 shift in emotional calibration.
 """
-from proselint.tools import existence_check, memoize
+from proselint.tools import existence_check, max_errors, memoize
 
 
+@max_errors(3)
 @memoize
 def check(text):
     """Advice on sudden vs suddenly."""
@@ -34,5 +35,5 @@ def check(text):
     msg = "Suddenly is nondescript, slows the action, and warns your reader."
     regex = "Suddenly,"
 
-    return existence_check(text, [regex], err, msg, max_errors=3,
-                           require_padding=False, offset=-1, ignore_case=False)
+    return existence_check(text, [regex], err, msg, require_padding=False,
+                           offset=-1, ignore_case=False)

--- a/proselint/checks/mixed_metaphors/misc.py
+++ b/proselint/checks/mixed_metaphors/misc.py
@@ -1,8 +1,10 @@
 """Mixed metaphors."""
 
-from proselint.tools import existence_check, memoize, preferred_forms_check
+from proselint.tools import (existence_check, max_errors, memoize,
+                             preferred_forms_check)
 
 
+@max_errors(1)
 @memoize
 def check_bottleneck(text):
     """Avoid mixing metaphors about bottles and their necks.
@@ -22,7 +24,7 @@ def check_bottleneck(text):
         "massive bottleneck",
     ]
 
-    return existence_check(text, list, err, msg, max_errors=1)
+    return existence_check(text, list, err, msg)
 
 
 @memoize

--- a/proselint/checks/typography/exclamation.py
+++ b/proselint/checks/typography/exclamation.py
@@ -14,9 +14,10 @@ Too much yelling.
 """
 import re
 
-from proselint.tools import existence_check, memoize
+from proselint.tools import existence_check, max_errors, memoize
 
 
+@max_errors(1)
 @memoize
 def check_repeated_exclamations(text):
     """Check the text."""
@@ -25,9 +26,8 @@ def check_repeated_exclamations(text):
 
     regex = r"[\!]\s*?[\!]{1,}"
 
-    return existence_check(
-        text, [regex], err, msg, require_padding=False, ignore_case=False,
-        max_errors=1, dotall=True)
+    return existence_check(text, [regex], err, msg, require_padding=False,
+                           ignore_case=False, dotall=True)
 
 
 @memoize

--- a/proselint/checks/typography/symbols.py
+++ b/proselint/checks/typography/symbols.py
@@ -4,9 +4,10 @@ source:     Butterick's Practical Typography
 source_url: http://practicaltypography.com/
 """
 
-from proselint.tools import existence_check, memoize
+from proselint.tools import existence_check, max_errors, memoize
 
 
+@max_errors(3)
 @memoize
 def check_ellipsis(text):
     """Use an ellipsis instead of three dots."""
@@ -14,10 +15,11 @@ def check_ellipsis(text):
     msg = "'...' is an approximation, use the ellipsis symbol '…'."
     regex = r"\.\.\."
 
-    return existence_check(text, [regex], err, msg, max_errors=3,
-                           require_padding=False, offset=0)
+    return existence_check(text, [regex], err, msg, require_padding=False,
+                           offset=0)
 
 
+@max_errors(1)
 @memoize
 def check_copyright_symbol(text):
     """Use the copyright symbol instead of (c)."""
@@ -25,10 +27,10 @@ def check_copyright_symbol(text):
     msg = "(c) is a goofy alphabetic approximation, use the symbol ©."
     regex = r"\([cC]\)"
 
-    return existence_check(
-        text, [regex], err, msg, max_errors=1, require_padding=False)
+    return existence_check(text, [regex], err, msg, require_padding=False)
 
 
+@max_errors(3)
 @memoize
 def check_trademark_symbol(text):
     """Use the trademark symbol instead of (TM)."""
@@ -36,10 +38,10 @@ def check_trademark_symbol(text):
     msg = "(TM) is a goofy alphabetic approximation, use the symbol ™."
     regex = r"\(TM\)"
 
-    return existence_check(
-        text, [regex], err, msg, max_errors=3, require_padding=False)
+    return existence_check(text, [regex], err, msg, require_padding=False)
 
 
+@max_errors(3)
 @memoize
 def check_registered_trademark_symbol(text):
     """Use the registered trademark symbol instead of (R)."""
@@ -47,10 +49,10 @@ def check_registered_trademark_symbol(text):
     msg = "(R) is a goofy alphabetic approximation, use the symbol ®."
     regex = r"\([rR]\)"
 
-    return existence_check(
-        text, [regex], err, msg, max_errors=3, require_padding=False)
+    return existence_check(text, [regex], err, msg, require_padding=False)
 
 
+@max_errors(3)
 @memoize
 def check_sentence_spacing(text):
     """Use no more than two spaces after a period."""
@@ -58,10 +60,10 @@ def check_sentence_spacing(text):
     msg = "More than two spaces after the period; use 1 or 2."
     regex = r"\. {3}"
 
-    return existence_check(
-        text, [regex], err, msg, max_errors=3, require_padding=False)
+    return existence_check(text, [regex], err, msg, require_padding=False)
 
 
+@max_errors(3)
 @memoize
 def check_multiplication_symbol(text):
     """Use the multiplication symbol ×, not the lowercase letter x."""
@@ -69,10 +71,10 @@ def check_multiplication_symbol(text):
     msg = "Use the multiplication symbol ×, not the letter x."
     regex = r"[0-9]+ ?x ?[0-9]+"
 
-    return existence_check(
-        text, [regex], err, msg, max_errors=3, require_padding=False)
+    return existence_check(text, [regex], err, msg, require_padding=False)
 
 
+@max_errors(3)
 @memoize
 def check_curly_quotes(text):
     """Use curly quotes, not straight quotes."""
@@ -80,8 +82,7 @@ def check_curly_quotes(text):
     msg = 'Use curly quotes “”, not straight quotes "".'
     regex = r"\"[\w\s\d]+\""
 
-    return existence_check(
-        text, [regex], err, msg, max_errors=3, require_padding=False)
+    return existence_check(text, [regex], err, msg, require_padding=False)
 
 # @memoize
 # def check_en_dash_separated_names(text):

--- a/proselint/checks/weasel_words/very.py
+++ b/proselint/checks/weasel_words/very.py
@@ -13,9 +13,10 @@ Substitute 'damn' every time you're inclined to write 'very'; your editor will
 delete it and the writing will be just as it should be.
 
 """
-from proselint.tools import existence_check, memoize
+from proselint.tools import existence_check, max_errors, memoize
 
 
+@max_errors(1)
 @memoize
 def check(text):
     """Avoid 'very'."""
@@ -25,4 +26,4 @@ def check(text):
            "and the writing will be just as it should be.")
     regex = "very"
 
-    return existence_check(text, [regex], err, msg, max_errors=1)
+    return existence_check(text, [regex], err, msg)


### PR DESCRIPTION
## This relates to...

Converting `truncate_to_max` to a decorator as a meta-check. This blocks #1188.

## Changes

- convert `max_errors` to a decorator

### Features

- export `max_errors` check decorator

### Bug Fixes

N/A.

### Breaking Changes and Deprecations

N/A.
