### PR TITLE
fix: load default config if none specified

### DIFF
--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -13,6 +13,7 @@ import shelve
 import sys
 import traceback
 from warnings import showwarning as warn
+
 from . import config
 
 _cache_shelves = dict()

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -13,6 +13,7 @@ import shelve
 import sys
 import traceback
 from warnings import showwarning as warn
+from . import config
 
 _cache_shelves = dict()
 proselint_path = os.path.dirname(os.path.realpath(__file__))
@@ -228,9 +229,8 @@ def line_and_column(text, position):
     return (line_no, position - position_counter)
 
 
-def lint(input_file, debug=False, config=None):
+def lint(input_file, debug=False, config=config.default):
     """Run the linter on the input file."""
-    config = config or {}
     if isinstance(input_file, str):
         text = input_file
     else:


### PR DESCRIPTION
Avoids crash in Python if configuration is not specified. Fixes #1240.