### PR TITLE
docs: config -> config.json in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ This will return a list of suggestions:
 
 ### Checks
 
-You can disable any of the checks by modifying `$XDG_CONFIG_HOME/proselint/config`. If `$XDG_CONFIG_HOME` is not set or empty, `~/.config/proselint/config` will be used. Additionally, for compatibility reasons, the legacy configuration `~/.proselintrc` will be checked if `$XDG_CONFIG_HOME/proselint/config` does not exist.
+You can disable any of the checks by modifying `$XDG_CONFIG_HOME/proselint/config.json`.
+If `$XDG_CONFIG_HOME` is not set or empty, `~/.config/proselint/config.json` will be used.
+Additionally, for compatibility reasons, the legacy configurations `~/.proselintrc` and `$XDG_CONFIG_HOME/proselint/config` will be checked if `$XDG_CONFIG_HOME/proselint/config.json` does not exist.
 
 ```json
 {


### PR DESCRIPTION
Proselint gives me a warning when I call my config file `config` as specified in the readme.