### PR TITLE
docs: add refererence to Flymake

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ sudo apt install python3-proselint
 - A [demo editor](http://proselint.com/write)
 - [Sublime Text](https://github.com/amperser/proselint/tree/main/plugins/sublime/SublimeLinter-contrib-proselint)
 - [Atom Editor](https://github.com/smockle/linter-proselint) (thanks to [Clay Miller](https://github.com/smockle)).
-- [Emacs via Flycheck](http://www.flycheck.org/).
+- Emacs via [Flycheck](http://www.flycheck.org/) or via [Flymake](https://github.com/manuel-uberti/flymake-proselint)
 - Vim via [ALE](https://github.com/w0rp/ale) or [Syntastic](https://github.com/vim-syntastic/syntastic) (thanks to @lcd047, @Carreau, and [Daniel M. Capella](https://github.com/polyzen))
 - [Phabricator's `arc` CLI](https://github.com/google/arc-proselint) (thanks to [Jeff Verkoeyen](https://github.com/jverkoey))
 - [Danger](https://github.com/dbgrandi/danger-prose) (thanks to [David Grandinetti](https://github.com/dbgrandi) and [Orta Therox](https://github.com/orta))


### PR DESCRIPTION
Hi,

I'd like to suggest an edit to the README with a reference to [flymake-proselint](https://github.com/manuel-uberti/flymake-proselint), which is an Emacs' Flymake backend for `proselint`. I curated the backend and use it daily, by the way.

It can be useful for the ones who prefer the built-in Flymake over the external Flycheck.