### PR TITLE
Add support for disabling checks via comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ Additionally, for compatibility reasons, the legacy configurations `~/.proselint
 }
 ```
 
+You can also disable checks inside a file using special comments. Use
+`proselint: disable` to disable *all* checks or `proselint: disable=<check>` to
+disable only specific checks.
+
+```tex
+Here, all checks are used.
+% proselint: disable=nonwords.misc,weasel_words.very
+Here, the \texttt{nonwords.misc} and \texttt{weasel\_words.very}
+checks are disabled.
+% proselint: enable=nonwords.misc
+At this point, the \texttt{nonwords.misc} check has been reenabled.
+```
+
 | ID    | Description     |
 | ----- | --------------- |
 | `airlinese.misc` | Avoiding jargon of the airline industry |

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -248,10 +248,11 @@ def lint(input_file, debug=False, config=config.default):
 
         for error in result:
             (start, end, check, message, replacements) = error
+            if is_quoted(start, text):
+                continue
             (line, column) = line_and_column(text, start)
-            if not is_quoted(start, text):
-                errors += [(check, message, line, column, start, end,
-                            end - start, "warning", replacements)]
+            errors += [(check, message, line, column, start, end,
+                        end - start, "warning", replacements)]
 
         if len(errors) > config["max_errors"]:
             break

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -22,6 +22,41 @@ class TestLint(Check):
 This is also a no-good sentence.
 
 """
+        self.text_with_checks_disabled_forever_tex = """
+But this is a bad sentence.
+% proselint: disable
+There is doubtlessly an error in this one.
+This sentence is also very bad.
+Proselint should also check this sentence unrelentlessly.
+
+"""
+        self.text_with_checks_disabled_and_reenabled_tex = """
+But this is a bad sentence.
+% proselint: disable
+There is doubtlessly an error in this one.
+This sentence is also very bad.
+% proselint: enable
+Proselint should also check this sentence unrelentlessly.
+
+"""
+        self.text_with_checks_disabled_and_reenabled_html = """
+But this is a bad sentence.
+<!-- proselint: disable -->
+There is doubtlessly an error in this one.
+This sentence is also very bad.
+<!-- proselint: enable -->
+Proselint should also check this sentence unrelentlessly.
+
+"""
+        self.text_with_specific_check_disabled_tex = """
+But this is a bad sentence.
+% proselint: disable=nonwords.misc
+There is doubtlessly an error in this one.
+This sentence is also very bad.
+% proselint: enable=nonwords.misc
+Proselint should also check this sentence unrelentlessly.
+
+"""
         self.text_with_no_newline = """A very bad sentence."""
 
     def extract_line_col(self, error):
@@ -37,3 +72,19 @@ This is also a no-good sentence.
     def test_on_no_newlines(self):
         """Test that lint works on text without a terminal newline."""
         assert len(lint(self.text_with_no_newline)) == 1
+
+    def test_checks_disabled_forever_tex(self):
+        """Test that disabling all checks works on a (La)TeX document."""
+        assert len(lint(self.text_with_checks_disabled_forever_tex)) == 1
+
+    def test_checks_disabled_and_reenabled_tex(self):
+        """Test that disabling and reenabling all checks works on a (La)TeX document."""
+        assert len(lint(self.text_with_checks_disabled_and_reenabled_tex)) == 2
+
+    def test_checks_disabled_and_reenabled_html(self):
+        """Test that disabling and reenabling all checks works on an HTML document."""
+        assert len(lint(self.text_with_checks_disabled_and_reenabled_html)) == 2
+
+    def test_specific_check_disabled_tex(self):
+        """Test that disabling a specific check works on a (La)TeX document."""
+        assert len(lint(self.text_with_specific_check_disabled_tex)) == 3


### PR DESCRIPTION
In some cases, there is a false positive or the writer knowingly wants
to ignore a failing check *in a specific section of the text*, but not
the entire document.

With this change, checks can be enabled and re-enabled at any time using
special comments:

    Here, all checks are used.
    % proselint: disable
    No checks are enabled here.
    % proselint: enable
    All checks have been reenabled.

It's also possible to disable only some checks:

    Here, all checks are used.
    % proselint: disable=nonwords.misc,weasel_words.very
    Here, the \texttt{nonwords.misc} and \texttt{weasel\_words.very}
    checks are disabled.
    % proselint: enable=nonwords.misc
    At this point, the \texttt{nonwords.misc} check has been reenabled.

This aims to be markup-language agnostic by allowing any printable
non-word ASCII character  in front of `proselint: instead of maintaining
a list of allowed comment styles. Note that there mustn't be any word
characters, so toggling checks in the middle of a line is not possible,