### PR TITLE
fix: support hyphens in lexical illusion regex

### DIFF
--- a/proselint/checks/lexical_illusions/misc.py
+++ b/proselint/checks/lexical_illusions/misc.py
@@ -21,7 +21,7 @@ def check(text):
     """Check the text."""
     err = "lexical_illusions.misc"
     msg = "There's a lexical illusion here: a word is repeated."
-    regex = r"\b(\w+)(\b\s\1)+\b"
+    regex = r"\b(?<!\-)(\w+)(\b\s\1)+\b"
     exceptions = [r"^had had$", r"^that that$"]
 
     return existence_check(text, [regex], err, msg, exceptions=exceptions,

--- a/tests/test_lexical_illusions.py
+++ b/tests/test_lexical_illusions.py
@@ -26,3 +26,4 @@ class TestCheck(Check):
         assert self.passes("The practitioner's side")
         assert self.passes("An antimatter particle")
         assert self.passes("The theory")
+        assert self.passes("She had coffee at the Foo-bar bar.")


### PR DESCRIPTION
Fixes false positives like ["D-Bus bus configuration"](https://dbus.freedesktop.org/doc/dbus-daemon.1.html).