### PR TITLE
ci: pin runner image versions

### DIFF
--- a/.github/workflows/ci-lint-test.yml
+++ b/.github/workflows/ci-lint-test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.8", "3.9", "3.10", "pypy3.9", "pypy3.10"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-12, windows-2022]
     steps:
       - name: "[INIT] Checkout repository"
         uses: actions/checkout@v3


### PR DESCRIPTION
## This relates to...

The key change here is using macos-12 instead of macos-latest. This
prevents the runner from switching to arm64, for which there are no
compiled versions of older Python targets (i.e. 3.8, 3.9).
