### PR TITLE
fix(lint): add flag to prevent filtering quotes in lintfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ corpora/*
 dist/
 *.pstore
 .pre-commit-config.yaml
+.direnv/
 .hypothesis

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,4 @@ corpora/*
 dist/
 *.pstore
 .pre-commit-config.yaml
-.direnv/
 .hypothesis

--- a/proselint/checks/typography/symbols.py
+++ b/proselint/checks/typography/symbols.py
@@ -57,8 +57,7 @@ check_curly_quotes = Check(
     check_type=types.ExistenceSimple(pattern=r"\"[\w\s\d]+\""),
     path="typography.symbols.curly_quotes",
     message='Use curly quotes “”, not straight quotes "".',
-    flags=CheckFlags(results_limit=3),
-    allow_quotes=True,
+    flags=CheckFlags(results_limit=3, allow_quotes=True),
 )
 
 

--- a/proselint/checks/typography/symbols.py
+++ b/proselint/checks/typography/symbols.py
@@ -58,6 +58,7 @@ check_curly_quotes = Check(
     path="typography.symbols.curly_quotes",
     message='Use curly quotes “”, not straight quotes "".',
     flags=CheckFlags(results_limit=3),
+    allow_quotes=True,
 )
 
 

--- a/proselint/registry/checks/__init__.py
+++ b/proselint/registry/checks/__init__.py
@@ -92,6 +92,7 @@ class CheckFlags(NamedTuple):
     # be achieved via iterators instead of working with final lists.
     results_limit: int = 0
     ppm_threshold: int = 0
+    allow_quotes: bool = False
 
     @staticmethod
     def truncate(
@@ -157,7 +158,6 @@ class Check(NamedTuple):
     message: str = ""
     flags: CheckFlags = CheckFlags()
     ignore_case: bool = True
-    allow_quotes: bool = False
     offset: tuple[int, int] = (0, 0)
 
     # TODO: for 3.11+, RegexFlag.NOFLAG exists

--- a/proselint/registry/checks/__init__.py
+++ b/proselint/registry/checks/__init__.py
@@ -157,6 +157,7 @@ class Check(NamedTuple):
     message: str = ""
     flags: CheckFlags = CheckFlags()
     ignore_case: bool = True
+    allow_quotes: bool = False
     offset: tuple[int, int] = (0, 0)
 
     # TODO: for 3.11+, RegexFlag.NOFLAG exists

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -170,8 +170,8 @@ class LintFile:
                     for check in registry.get_all_enabled(config["checks"])
                     for result in check.check_with_flags(self.content)
                     if (
-                        not self.is_quoted_pos(result.start_pos)
-                        or check.flags.allow_quotes
+                        check.flags.allow_quotes
+                        or not self.is_quoted_pos(result.start_pos)
                     )
 
                 ),

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -121,7 +121,9 @@ class LintFile:
         self.content = f"\n{content}\n"
 
         self.line_bounds = self._line_bounds()
-        self.quote_spans = tuple(find_quoted_ranges(self.content))
+        self.quote_spans = tuple(
+            find_spans(self.content, QUOTE_PATTERN, check_matching_quotes)
+        )
 
     @classmethod
     def from_stdin(cls) -> "LintFile":
@@ -172,7 +174,11 @@ class LintFile:
                     )
                     for check in registry.get_all_enabled(config["checks"])
                     for result in check.check_with_flags(self.content)
-                    if not self.is_quoted_pos(result.start_pos)
+                    if (
+                        not self.is_quoted_pos(result.start_pos)
+                        or check.allow_quotes
+                    )
+
                 ),
                 config["max_errors"],
             ),

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -121,9 +121,7 @@ class LintFile:
         self.content = f"\n{content}\n"
 
         self.line_bounds = self._line_bounds()
-        self.quote_spans = tuple(
-            find_spans(self.content, QUOTE_PATTERN, check_matching_quotes)
-        )
+        self.quote_spans = tuple(find_quoted_ranges(self.content))
 
     @classmethod
     def from_stdin(cls) -> "LintFile":

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -76,11 +76,6 @@ def find_spans(
     return spans
 
 
-def find_quoted_ranges(text: str) -> list[tuple[int, int]]:
-    """Find the ranges of quote pairs in text."""
-    return find_spans(text, QUOTE_PATTERN, check_matching_quotes)
-
-
 def errors_to_json(errors: list[LintResult]) -> str:
     """Convert the errors to JSON."""
     return json.dumps(

--- a/proselint/tools.py
+++ b/proselint/tools.py
@@ -171,7 +171,7 @@ class LintFile:
                     for result in check.check_with_flags(self.content)
                     if (
                         not self.is_quoted_pos(result.start_pos)
-                        or check.allow_quotes
+                        or check.flags.allow_quotes
                     )
 
                 ),


### PR DESCRIPTION
- added an `allow_quotes` flag to `CheckFlag`s to allow proper matching of quotes
- removed dead code (`find_quoted_spans`)