### PR TITLE
fix(checks): resolve meantime/meanwhile conflict in misc.preferred_forms

### DIFF
--- a/proselint/checks/misc/preferred_forms.py
+++ b/proselint/checks/misc/preferred_forms.py
@@ -14,7 +14,10 @@ Points out preferred forms.
 
 """
 
-from proselint.registry.checks import Check, types
+from proselint.registry.checks import Check, Padding, types
+
+CHECK_PATH = "misc.preferred_forms"
+CHECK_MESSAGE = "'{}' is the preferred form."
 
 check = Check(
     check_type=types.PreferredFormsSimple(
@@ -123,7 +126,6 @@ check = Check(
             "maddening crowd": "madding crowd",
             "magna charta": "Magna Carta",
             "mariage de convenance": "marriage of convenience",
-            "meantime,": "Meanwhile,",
             "middle west": "Midwest",
             "middle western": "Midwestern",
             "modes of operandi": "modi operandi",
@@ -176,4 +178,23 @@ check = Check(
     message="'{}' is the preferred form.",
 )
 
-__register__ = (check,)
+check_meantime_capital = Check(
+    check_type=types.PreferredForms(items={
+        r"\bMeantime,\B": "Meanwhile,",
+    }, padding=Padding.RAW),
+    path=CHECK_PATH,
+    message=CHECK_MESSAGE,
+    ignore_case=False,
+)
+
+check_meantime_clause = Check(
+    check_type=types.PreferredForms(items={
+        r"[;,] meantime,\B": "meanwhile,"
+    }, padding=Padding.RAW),
+    path=CHECK_PATH,
+    message=CHECK_MESSAGE,
+    ignore_case=False,
+    offset=(2, 0),
+)
+
+__register__ = (check, check_meantime_capital, check_meantime_clause)

--- a/proselint/checks/misc/preferred_forms.py
+++ b/proselint/checks/misc/preferred_forms.py
@@ -189,7 +189,7 @@ check_meantime_capital = Check(
 
 check_meantime_clause = Check(
     check_type=types.PreferredForms(items={
-        r"[;,] meantime,\B": "meanwhile,"
+        r"\b[;,] meantime,\B": "meanwhile,"
     }, padding=Padding.RAW),
     path=CHECK_PATH,
     message=CHECK_MESSAGE,

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -314,8 +314,16 @@ data: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         (
             "It was almost haloween.",
             "He is Chief Justice of the Supreme Court of the United States.",
+            "Meantime, I had tea.",
+            "In the meanwhile, something happened.",
+            "She went to bed; meantime, I had tea.",
         ),
-        ("Smoke phrase with nothing flagged.",),
+        (
+            "Smoke phrase with nothing flagged.",
+            "Meanwhile, I had tea.",
+            "In the meantime, something happened.",
+            "She went to bed; meanwhile, I had tea."
+        ),
     ),
     (
         "misc.pretension",


### PR DESCRIPTION
## Relevant issues

Fixes #1379.

## Brief

Resolve a conflicting suggestion between "In the meantime," and "Meanwhile," in `misc.preferred_forms`.

## Changes

- Factor the "Meantime," check out of `misc.preferred_forms` into two checks
  1. "Meantime," at the beginning of a sentence
  2. "meantime," at the beginning of a clause (e.g. following a comma or semicolon)
- Update tests accordingly