### PR TITLE
fix(checks): allow very well in weasel_words

### DIFF
--- a/proselint/checks/weasel_words.py
+++ b/proselint/checks/weasel_words.py
@@ -15,10 +15,12 @@ Weasel words.
 
 """
 
-from proselint.registry.checks import Check, types
+from proselint.registry.checks import Check, Padding, types
 
 check_very = Check(
-    check_type=types.ExistenceSimple(pattern="very"),
+    check_type=types.ExistenceSimple(
+        pattern=Padding.WORDS_IN_TEXT.format(r"very(?! well)")
+    ),
     path="weasel_words.very",
     message=(
         "Substitute 'damn' every time you're inclined to write 'very'; your"

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -499,7 +499,11 @@ data: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
     (
         "weasel_words",
         ("The book was very interesting.",),
-        ("Smoke phrase with nothing flagged.",),
+        (
+            "Smoke phrase with nothing flagged.",
+            "Very well, Headmaster, thank you.",
+            "The discovery and development of new approaches."
+        ),
     ),
     (
         "restricted.elementary",


### PR DESCRIPTION
## Relevant issues

Fixes #1308.

## Brief

Allow "very well" in `weasel_words.very`, as a special case. See the issue for related discussion.

## Changes

- Add an exception to `weasel_words.very` that allows "very well"
- Fix a padding issue where `weasel_words.very` lacked boundary checks, causing words like "discovery" to create false-positives
- Update test examples for `weasel_words`
