### PR TITLE
chore(deps): ignore uv_build in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,5 +22,6 @@
     }
   ],
   "labels": ["cat: deps", "type: chore"],
-  "ignorePaths": ["Gemfile", "plugins/"]
+  "ignorePaths": ["Gemfile", "plugins/"],
+  "ignoreDeps": ["uv_build"]
 }


### PR DESCRIPTION
## Brief

Currently, Renovate frequently creates pull requests like #1424 to update `uv_build`, but this is erroneous - `uv_build`  is versioned alongside `uv`, which is managed by the Nix flake.

## Changes

- Add `uv_build` to `ignoreDeps` in the Renovate configuration