### PR TITLE
perf(registry): early exit matches_partial

### DIFF
--- a/proselint/registry/checks/__init__.py
+++ b/proselint/registry/checks/__init__.py
@@ -145,6 +145,9 @@ class Check(NamedTuple):
 
     def matches_partial(self, partial: str) -> bool:
         """Check if `partial` is a subset key of the full check path."""
+        if self.path == partial:
+            return True
+
         partial_segments = partial.split(".")
 
         return self.path_segments[: len(partial_segments)] == partial_segments

--- a/proselint/registry/checks/__init__.py
+++ b/proselint/registry/checks/__init__.py
@@ -145,12 +145,7 @@ class Check(NamedTuple):
 
     def matches_partial(self, partial: str) -> bool:
         """Check if `partial` is a subset key of the full check path."""
-        if self.path == partial:
-            return True
-
-        partial_segments = partial.split(".")
-
-        return self.path_segments[: len(partial_segments)] == partial_segments
+        return self.path == partial or self.path.startswith(f"{partial}.")
 
     def check(self, text: str) -> Iterator[CheckResult]:
         """Apply the check over `text`."""


### PR DESCRIPTION
## Relevant issues

Intended to help with #1440.

## Brief

Improve performance of `check.matches_partial` by 85% in the case of a full match using a fast equality, and 66% in all other cases by using `startswith`. 

## Acknowledgements

Credit to @drainpixie for noticing the equivalence of these operations.