### PR TITLE
build: replace uv_build with pdm-backend 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "proselint"
 description = "A linter for prose."
 version = "0.16.0"
-license = {file = "LICENSE.md"}
+license = { file = "LICENSE.md" }
 authors = [{ name = "Amperser Labs", email = "hello@amperser.com"}]
 readme = "README.md"
 classifiers = [
@@ -29,8 +29,8 @@ Issues = "https://github.com/amperser/proselint/issues"
 proselint = "proselint.command_line:main"
 
 [build-system]
-requires = ["uv_build>=0.7.22,<0.8.0"]
-build-backend = "uv_build"
+requires = ["pdm-backend>=2.0.0"]
+build-backend = "pdm.backend"
 
 [tool.poe.tasks]
 test = "pytest"
@@ -62,10 +62,9 @@ web = [
 	"rq>=0.12.0",
 ]
 
-[tool.uv.build-backend]
-module-name = "proselint"
-module-root = ""
-source-include = ["tests/**"]
+[tool.pdm.build]
+includes = ["proselint/"]
+source-includes = ["tests/"]
 
 [tool.ruff]
 line-length = 80


### PR DESCRIPTION
## Relevant issues

Resolves #1450. Resolves #1452.

## Brief

`uv_build` is not available on some previously supported systems. While faster than `pdm-backend`, the difference is negligible, and `pdm-backend` is available everywhere Python is. This ensures all supported systems remain compatible for 0.16 onwards.

## Changes

- Remove the deprecated `License` trove classifier
- Use `pdm-backend` instead of `uv_build`