### PR TITLE
refactor(config)!: turn typography off by default

### DIFF
--- a/proselint/config/default.json
+++ b/proselint/config/default.json
@@ -22,7 +22,7 @@
         "social_awareness": true,
         "spelling": true,
         "terms": true,
-        "typography": true,
+        "typography": false,
         "uncomparables": true,
         "weasel_words": true
     }


### PR DESCRIPTION
## Relevant issues

Related to discussion on #1466 and #1405.

## Brief

Previously, the `typography` module would create issues with non-plaintext files, so the default configuration has been adjusted here to reduce friction for users working with such files.

## Changes

- Turn off the `typography` module by default.