### PR TITLE
refactor(config)!: remove legacy config paths

### DIFF
--- a/proselint/config/paths.py
+++ b/proselint/config/paths.py
@@ -17,13 +17,10 @@ def _get_xdg_path(env_var: str, default: Path) -> Path:
     return Path(xdg_path) if (xdg_path := os.environ.get(env_var)) else default
 
 
-config_global_path = Path("/etc/proselintrc")
 config_user_path = _get_xdg_path(XDG_CONFIG_VAR, home_path / ".config")
 
 config_paths = [
     # NOTE: This is in reverse priority order - the order config gets merged in
-    config_global_path,
-    home_path / ".proselintrc.json",
     config_user_path / "proselint" / "config.json",
     cwd / ".proselintrc.json",
 ]


### PR DESCRIPTION
## Brief

Removes the legacy config paths for global and per-user home configuration.