### PR TITLE
refactor(config)!: make per-project config visible

### DIFF
--- a/proselint/config/paths.py
+++ b/proselint/config/paths.py
@@ -22,5 +22,5 @@ config_user_path = _get_xdg_path(XDG_CONFIG_VAR, home_path / ".config")
 config_paths = [
     # NOTE: This is in reverse priority order - the order config gets merged in
     config_user_path / "proselint" / "config.json",
-    cwd / ".proselintrc.json",
+    cwd / "proselint.json",
 ]


### PR DESCRIPTION
## Relevant issues

Blocked by #1472.

## Brief

It can be surprising for Proselint to run differently in a directory when, at a glance, there are no configuration files for it. This rationale has been used by a plethora of other linters to switch away from older `.config.extension` files to simply `config.extension`. It is time Proselint follows suit.

## Changes

- Rename `.proselintrc.json` to `proselint.json`