### PR TITLE
refactor(config)!: stop searching after file is found

### DIFF
--- a/proselint/config/__init__.py
+++ b/proselint/config/__init__.py
@@ -77,16 +77,14 @@ def load_from(config_path: Path | None = None) -> Config:
 
     NOTE: This assumes that a `config_path` is valid if one is provided.
     """
-    result = DEFAULT
-    config_paths = paths.config_paths + ([config_path] if config_path else [])
-
-    for path in filter(Path.is_file, config_paths):
-        result = _deepmerge_dicts(
-            cast("dict[str, object]", result),
-            json.loads(path.read_text()),  # pyright: ignore[reportAny]
+    config_paths = ([config_path] if config_path else []) + paths.config_paths
+    try:
+        result = cast(
+            "Config",
+            json.loads(next(filter(Path.is_file, config_paths)).read_text()),
         )
-
-    result = cast("Config", result)
+    except StopIteration:
+        return DEFAULT
 
     return Config(
         max_errors=result.get("max_errors", 0),

--- a/proselint/config/paths.py
+++ b/proselint/config/paths.py
@@ -20,7 +20,6 @@ def _get_xdg_path(env_var: str, default: Path) -> Path:
 config_user_path = _get_xdg_path(XDG_CONFIG_VAR, home_path / ".config")
 
 config_paths = [
-    # NOTE: This is in reverse priority order - the order config gets merged in
-    config_user_path / "proselint" / "config.json",
     cwd / "proselint.json",
+    config_user_path / "proselint" / "config.json",
 ]


### PR DESCRIPTION
## Relevant issues

Blocked by #1473. Resolves an objective of #1375.

## Brief

This removes the implicit merging behaviour, instead searching the paths and stopping at the first instance of a usable config, or falling back to the default.

## Changes

- Reverse priorities of `proselint.config.config_paths`
- Remove implicit merging from `proselint.config.load_from`