### PR TITLE
feat(config): walk file hierarchy for project config

### DIFF
--- a/proselint/config/paths.py
+++ b/proselint/config/paths.py
@@ -1,6 +1,7 @@
 """Configuration paths for proselint."""
 
 import os
+from itertools import repeat
 from pathlib import Path
 
 XDG_CONFIG_VAR = "XDG_CONFIG_HOME"
@@ -21,5 +22,6 @@ config_user_path = _get_xdg_path(XDG_CONFIG_VAR, home_path / ".config")
 
 config_paths = [
     cwd / "proselint.json",
+    *map(Path.__truediv__, cwd.parents, repeat("proselint.json")),
     config_user_path / "proselint" / "config.json",
 ]


### PR DESCRIPTION
## Relevant issues

Blocked by #1474. Resolves an objective of #1375. Required for #1466.

## Brief

The current naïve implementation of attempting to load configuration from the current working directory is insufficient for having project-wide selection of checks. Here, we traverse the file tree up from the current working directory in search of configuration files, enabling proselint to find them at the project root.

## Changes

- Walk the filesystem hierarchy to find project configuration above the current working directory