### PR TITLE
fix: pre-commit hook file type filter

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
   description: This hook checks language usage and style in text files.
   entry: proselint
   language: python
-  types: [html, markdown, plain-text, tex]
+  types_or: [html, markdown, plain-text, tex]
   args: [check]


### PR DESCRIPTION
## Relevant issues

In https://github.com/amperser/proselint/pull/1465, I only did a manual test for the initial commit, but not for subsequent ones. This way, I broke the file filter and now, the hook doesn't apply to any file, but just skips all of them. For example for a markdown file:

<img width="756" height="79" alt="image" src="https://github.com/user-attachments/assets/bdf231eb-62da-4e13-a90e-645afcbdb2ac" />


## Brief

Fix the pre-commit hook to apply to any of the listed file types.

## Changes

same as brief. With this change, I get

<img width="799" height="156" alt="image" src="https://github.com/user-attachments/assets/04754b0c-2aa1-4067-9cb5-150af9e2c36e" />

So the hook applies to the correct files again. 

Why did this break? Because of [this logic](https://pre-commit.com/#filtering-files-with-types:~:text=types%2C%20types%5For%2C%20and%20files%20are%20evaluated%20together%20with%20AND%20when%20filtering%2E%20Tags%20within%20types%20are%20also%20evaluated%20using%20AND%2E):

> `types`, `types_or`, and `files` are evaluated together with AND when filtering. Tags within types are also evaluated using AND.

So the hook tried to find files that are simultaneously markdown, html, txt, and tex. In contrast to this,

> Tags within `types_or` are evaluated using OR.

So that's the field we want to set.