### PR TITLE
Document GitLab CICD job definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,9 @@ nix profile install nixpkgs#proselint
 
 ```bash
 lint-prose:
-  image:
-    name: bengt/alpine-proselint:alpine-3.23
+  image: bengt/alpine-proselint:alpine-3.23
   script:
-    - proselint check README.md .gitlab/README.md
-  stage: lint
+    - proselint check *.md
 ```
 
 ### Plugins for other software

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ nix profile install nixpkgs#proselint
 
 [`nixpkgs`]: https://search.nixos.org/packages?channel=25.05&show=proselint
 
-### GitLab CICD Pipeline Job
+### GitLab CI/CD Pipeline Job
 
 ```yaml
 lint-prose:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ nix profile install nixpkgs#proselint
 
 ### GitLab CICD Pipeline Job
 
-```bash
+```yaml
 lint-prose:
   image: bengt/alpine-proselint:alpine-3.23
   script:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ nix profile install nixpkgs#proselint
 
 [`nixpkgs`]: https://search.nixos.org/packages?channel=25.05&show=proselint
 
+### GitLab CICD Pipeline Job
+
+```bash
+lint-prose:
+  image:
+    name: bengt/alpine-proselint:alpine-3.23
+  script:
+    - proselint check README.md .gitlab/README.md
+  stage: lint
+```
+
 ### Plugins for other software
 
 `proselint` is available on:


### PR DESCRIPTION
## Relevant issues

Decide whether or not you want to provide a Docker Image yourself.

## Brief

This pull request documents how to use proselint in a GitLab CI pipeline job.

## Changes

- Add an example GitLab pipeline job definition to the `README.md` file.